### PR TITLE
Adding Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+language: python
+python:
+  - "2.7"
+install:
+    - pip install -r test_requirements.txt
+    - pip install coveralls
+script:
+    ./build
+after_success:
+    coveralls
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # GreenPiThumb
 
+[![Build
+Status](https://travis-ci.org/JeetShetty/GreenPiThumb.svg?branch=master)](https://travis-ci.org/JeetShetty/GreenPiThumb)
+[![Coverage
+Status](https://coveralls.io/repos/JeetShetty/GreenPiThumb/badge.svg?branch=master&service=github)](https://coveralls.io/github/JeetShetty/GreenPiThumb?branch=master)
+
 GreenPiThumb is a program that automatically waters a plant based on soil moisture levels, and records and displays the following:
 - Ambient temperature
 - Ambient humidity

--- a/build
+++ b/build
@@ -1,0 +1,1 @@
+coverage run --source greenpithumb -m unittest discover


### PR DESCRIPTION
Adds Travis configuration to GreenPiThumb so that every commit has unit tests
automatically run on a test system.