### PR TITLE
Adding DHT11 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dht11"]
+	path = dht11
+	url = https://github.com/szazo/DHT11_Python.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.7"
 install:
+    - pip install -r requirements.txt
     - pip install -r test_requirements.txt
     - pip install coveralls
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+RPi.GPIO


### PR DESCRIPTION
Adding the Python DHT11 library as a submodule and adding a dependency on
RPi.GPIO since DHT11 needs it.