### PR TITLE
Fix soil sensor

### DIFF
--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -10,6 +10,7 @@ import dht11
 import humidity_sensor
 import light_sensor
 import moisture_sensor
+import pi_io
 import temperature_sensor
 import wiring_config_parser
 
@@ -29,7 +30,8 @@ class SensorHarness(object):
         self._light_sensor = light_sensor.LightSensor(
             self._adc, wiring_config.adc_channels.light_sensor)
         self._moisture_sensor = moisture_sensor.MoistureSensor(
-            self._adc, GPIO, wiring_config.adc_channels.soil_moisture_sensor,
+            self._adc,
+            pi_io.IO(GPIO), wiring_config.adc_channels.soil_moisture_sensor,
             wiring_config.gpio_pins.soil_moisture_1,
             wiring_config.gpio_pins.soil_moisture_2, local_clock)
         self._dht11 = dht11.CachingDHT11(

--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -3,6 +3,7 @@ import time
 
 import Adafruit_DHT
 import Adafruit_MCP3008
+import RPi.GPIO as GPIO
 
 import clock
 import dht11
@@ -28,7 +29,9 @@ class SensorHarness(object):
         self._light_sensor = light_sensor.LightSensor(
             self._adc, wiring_config.adc_channels.light_sensor)
         self._moisture_sensor = moisture_sensor.MoistureSensor(
-            self._adc, wiring_config.adc_channels.soil_moisture_sensor)
+            self._adc, GPIO, wiring_config.adc_channels.soil_moisture_sensor,
+            wiring_config.gpio_pins.soil_moisture_1,
+            wiring_config.gpio_pins.soil_moisture_2, local_clock)
         self._dht11 = dht11.CachingDHT11(
             lambda: Adafruit_DHT.read_retry(Adafruit_DHT.DHT11, wiring_config.gpio_pins.dht11),
             local_clock)

--- a/greenpithumb/pi_io.py
+++ b/greenpithumb/pi_io.py
@@ -13,7 +13,7 @@ class IO(object):
             gpio: Raspberry Pi GPIO module.
         """
         self._GPIO = gpio
-        self._GPIO.setmode(self._GPIO.BOARD)
+        self._GPIO.setmode(self._GPIO.BCM)
         self._output_pins = set()
 
     def turn_pin_on(self, pin):

--- a/greenpithumb/wiring_config.ini.example
+++ b/greenpithumb/wiring_config.ini.example
@@ -3,8 +3,8 @@
 [gpio_pins]
 pump: 26
 dht11: 21
-soil_moisture_1: 16
-soil_moisture_2: 12
+soil_moisture_1: 12
+soil_moisture_2: 16
 mcp3008_clk: 18
 mcp3008_dout: 23
 mcp3008_din: 24

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytz
 tzlocal
 python-dateutil
+RPi.GPIO


### PR DESCRIPTION
Updating soil moisture sensor in greenpithumb.py to match the new parameters we added to the constructor in #53.

Fixes the mode to be BCM so that it matches the numbering on fritzing diagrams on the Raspberry Pi cobbler.

Fixes the wiring config example because the pins were reversed, causing the calculation to start at 1023 going down rather than 0 going up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jeetshetty/greenpithumb/63)
<!-- Reviewable:end -->
