### PR TITLE
Fixing TODO about wiring naming

### DIFF
--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -18,8 +18,12 @@ class SensorHarness(object):
 
     def __init__(self, wiring_config):
         local_clock = clock.LocalClock()
-        # TODO(mtlynch): Fix the wiring config pin names so they match the
-        # params to MCP3008's constructor.
+        # The MCP3008 spec and Adafruit library use different naming for the
+        # Raspberry Pi GPIO pins, so we translate as follows:
+        # * CLK -> CLK
+        # * CS/SHDN -> CS
+        # * DOUT -> MISO
+        # * DIN -> MOSI
         self._adc = Adafruit_MCP3008.MCP3008(
             clk=wiring_config.gpio_pins.mcp3008_clk,
             cs=wiring_config.gpio_pins.mcp3008_cs_shdn,


### PR DESCRIPTION
I thought I had the naming wrong for the MCP3008's pins, but it turns out
that the MCP3008 spec and the Adafruit library just use different names for
the same pins. This replaces the TODO with an explanation of the
translation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jeetshetty/greenpithumb/64)
<!-- Reviewable:end -->
