### PR TITLE
Reordering build checks so that pyflakes precedes YAPF

### DIFF
--- a/build
+++ b/build
@@ -11,6 +11,9 @@ coverage run \
   --omit "greenpithumb/dht11/*,greenpithumb/fake_sensors.py" \
   -m unittest discover
 
+# Run static analysis for Python bugs/cruft.
+pyflakes greenpithumb/*.py tests/*.py
+
 # Check that source has correct formatting.
 yapf \
   --diff \
@@ -19,9 +22,6 @@ yapf \
   ./ \
   --exclude "./greenpithumb/dht11/*" \
   --exclude "./third_party/*"
-
-# Run static analysis for Python bugs/cruft.
-pyflakes greenpithumb/*.py tests/*.py
 
 # Check that docstrings are formatted correctly.
 PYTHONPATH=$PYTHONPATH:$(pwd)/third_party/docstringchecker \


### PR DESCRIPTION
If there's a syntax error in a file not covered by unit tests, YAPF will crash
whereas pyflakes will fail gracefully with a helpful error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jeetshetty/greenpithumb/66)
<!-- Reviewable:end -->
