### PR TITLE
Changing DbStore semantics to store records

### DIFF
--- a/tests/test_db_store.py
+++ b/tests/test_db_store.py
@@ -61,15 +61,16 @@ class StoreClassesTest(unittest.TestCase):
 
     def test_store_soil_moisture(self):
         """Should insert timestamp and moisture level into database."""
-        timestamp = datetime.datetime(
-            2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc)
-        soil_moisture = 300
+        record = db_store.SoilMoistureRecord(
+            timestamp=datetime.datetime(
+                2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
+            soil_moisture=300)
         mock_cursor = mock.Mock()
         store = db_store.SoilMoistureStore(mock_cursor)
-        store.store_soil_moisture(timestamp, soil_moisture)
+        store.store_soil_moisture(record)
         mock_cursor.execute.assert_called_once_with(
             'INSERT INTO soil_moisture VALUES (?, ?)', (
-                '2016-07-23T10:51:09.928000+00:00', soil_moisture))
+                '2016-07-23T10:51:09.928000+00:00', 300))
 
     def test_latest_soil_moisture(self):
         mock_cursor = mock.Mock()
@@ -116,15 +117,16 @@ class StoreClassesTest(unittest.TestCase):
 
     def test_store_ambient_light(self):
         """Should insert timestamp and ambient light into database."""
-        timestamp = datetime.datetime(
-            2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc)
-        ambient_light = 50.0
+        ambient_light_record = db_store.AmbientLightRecord(
+            timestamp=datetime.datetime(
+                2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
+            ambient_light=50.0)
         mock_cursor = mock.Mock()
         store = db_store.AmbientLightStore(mock_cursor)
-        store.store_ambient_light(timestamp, ambient_light)
+        store.store_ambient_light(ambient_light_record)
         mock_cursor.execute.assert_called_once_with(
             'INSERT INTO ambient_light VALUES (?, ?)', (
-                '2016-07-23T10:51:09.928000+00:00', ambient_light))
+                '2016-07-23T10:51:09.928000+00:00', 50.0))
 
     def test_retrieve_ambient_light(self):
         mock_cursor = mock.Mock()
@@ -157,15 +159,16 @@ class StoreClassesTest(unittest.TestCase):
 
     def test_store_humidity(self):
         """Should insert timestamp and humidity level into database."""
-        timestamp = datetime.datetime(
-            2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc)
-        humidity = 50.0
+        humidity_record = db_store.HumidityRecord(
+            timestamp=datetime.datetime(
+                2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
+            humidity=50.0)
         mock_cursor = mock.Mock()
         store = db_store.HumidityStore(mock_cursor)
-        store.store_humidity(timestamp, humidity)
+        store.store_humidity(humidity_record)
         mock_cursor.execute.assert_called_once_with(
             'INSERT INTO ambient_humidity VALUES (?, ?)',
-            ('2016-07-23T10:51:09.928000+00:00', humidity))
+            ('2016-07-23T10:51:09.928000+00:00', 50.0))
 
     def test_retrieve_humidity(self):
         mock_cursor = mock.Mock()
@@ -197,15 +200,16 @@ class StoreClassesTest(unittest.TestCase):
 
     def test_store_temperature(self):
         """Should insert timestamp and temperature into database."""
-        timestamp = datetime.datetime(
-            2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc)
-        temperature = 21.1
+        temperature_record = db_store.TemperatureRecord(
+            timestamp=datetime.datetime(
+                2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
+            temperature=21.1)
         mock_cursor = mock.Mock()
         store = db_store.TemperatureStore(mock_cursor)
-        store.store_temperature(timestamp, temperature)
+        store.store_temperature(temperature_record)
         mock_cursor.execute.assert_called_once_with(
             'INSERT INTO temperature VALUES (?, ?)',
-            ('2016-07-23T10:51:09.928000+00:00', temperature))
+            ('2016-07-23T10:51:09.928000+00:00', 21.1))
 
     def test_retrieve_temperature(self):
         mock_cursor = mock.Mock()
@@ -238,15 +242,16 @@ class StoreClassesTest(unittest.TestCase):
 
     def test_store_water_pumped(self):
         """Should insert timestamp and volume of water pumped into database."""
-        timestamp = datetime.datetime(
-            2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc)
-        water_pumped = 200.0
+        watering_event_record = db_store.WateringEventRecord(
+            timestamp=datetime.datetime(
+                2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
+            water_pumped=200.0)
         mock_cursor = mock.Mock()
         store = db_store.WateringEventStore(mock_cursor)
-        store.store_water_pumped(timestamp, water_pumped)
+        store.store_water_pumped(watering_event_record)
         mock_cursor.execute.assert_called_once_with(
             'INSERT INTO watering_events VALUES (?, ?)', (
-                '2016-07-23T10:51:09.928000+00:00', water_pumped))
+                '2016-07-23T10:51:09.928000+00:00', 200.0))
 
     def test_retrieve_water_pumped(self):
         mock_cursor = mock.Mock()


### PR DESCRIPTION
Changing semantics of the DbStore classes so that the caller supplies record
objects instead of (timestamp, value) parameters. This brings parity to the
store and retrieve functions and makes it possible to build another class that
can handle generic database records.