### PR TITLE
Changing poller semantics to make them stoppable

### DIFF
--- a/greenpithumb/poller.py
+++ b/greenpithumb/poller.py
@@ -14,18 +14,23 @@ class SensorPollerBase(object):
         """
         self._local_clock = local_clock
         self._poll_interval = poll_interval
+        self._closed = threading.Event()
 
-    def _poll_forever(self):
-        """Polls, forever, at a fixed interval."""
-        while True:
+    def _poll(self):
+        """Polls at a fixed interval until caller calls close()."""
+        while not self._closed.is_set():
             self._poll_once()
             self._local_clock.wait(self._poll_interval)
 
     def start_polling_async(self):
         """Starts a new thread to begin polling."""
-        t = threading.Thread(target=self._poll_forever)
+        t = threading.Thread(target=self._poll)
         t.setDaemon(True)
         t.start()
+
+    def close(self):
+        """Stops polling."""
+        self._closed.set()
 
 
 class TemperaturePoller(SensorPollerBase):

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime
 import threading
 import unittest
@@ -21,58 +22,62 @@ class PollerClassesTest(unittest.TestCase):
         self.mock_store = mock.Mock()
 
     def test_temperature_poller(self):
-        temperature_poller = poller.TemperaturePoller(
-            self.mock_local_clock, POLL_INTERVAL, self.mock_sensor,
-            self.mock_store)
-        self.mock_local_clock.now.return_value = TIMESTAMP_A
-        self.mock_local_clock.wait.side_effect = (
-            lambda _: self.clock_wait_event.set())
-        self.mock_sensor.temperature.return_value = 21.0
+        with contextlib.closing(
+                poller.TemperaturePoller(
+                    self.mock_local_clock, POLL_INTERVAL, self.mock_sensor,
+                    self.mock_store)) as temperature_poller:
+            self.mock_local_clock.now.return_value = TIMESTAMP_A
+            self.mock_local_clock.wait.side_effect = (
+                lambda _: self.clock_wait_event.set())
+            self.mock_sensor.temperature.return_value = 21.0
 
-        temperature_poller.start_polling_async()
-        self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            temperature_poller.start_polling_async()
+            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
         self.mock_store.store_temperature.assert_called_with(TIMESTAMP_A, 21.0)
         self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
 
     def test_humidity_poller(self):
-        humidity_poller = poller.HumidityPoller(self.mock_local_clock,
-                                                POLL_INTERVAL, self.mock_sensor,
-                                                self.mock_store)
-        self.mock_local_clock.now.return_value = TIMESTAMP_A
-        self.mock_local_clock.wait.side_effect = (
-            lambda _: self.clock_wait_event.set())
-        self.mock_sensor.humidity.return_value = 50.0
+        with contextlib.closing(
+                poller.HumidityPoller(self.mock_local_clock, POLL_INTERVAL,
+                                      self.mock_sensor,
+                                      self.mock_store)) as humidity_poller:
+            self.mock_local_clock.now.return_value = TIMESTAMP_A
+            self.mock_local_clock.wait.side_effect = (
+                lambda _: self.clock_wait_event.set())
+            self.mock_sensor.humidity.return_value = 50.0
 
-        humidity_poller.start_polling_async()
-        self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            humidity_poller.start_polling_async()
+            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
         self.mock_store.store_humidity.assert_called_with(TIMESTAMP_A, 50.0)
         self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
 
     def test_moisture_poller(self):
-        moisture_poller = poller.MoisturePoller(self.mock_local_clock,
-                                                POLL_INTERVAL, self.mock_sensor,
-                                                self.mock_store)
-        self.mock_local_clock.now.return_value = TIMESTAMP_A
-        self.mock_local_clock.wait.side_effect = (
-            lambda _: self.clock_wait_event.set())
-        self.mock_sensor.moisture.return_value = 300
+        with contextlib.closing(
+                poller.MoisturePoller(self.mock_local_clock, POLL_INTERVAL,
+                                      self.mock_sensor,
+                                      self.mock_store)) as moisture_poller:
+            self.mock_local_clock.now.return_value = TIMESTAMP_A
+            self.mock_local_clock.wait.side_effect = (
+                lambda _: self.clock_wait_event.set())
+            self.mock_sensor.moisture.return_value = 300
 
-        moisture_poller.start_polling_async()
-        self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            moisture_poller.start_polling_async()
+            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
         self.mock_store.store_soil_moisture.assert_called_with(TIMESTAMP_A, 300)
         self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
 
     def test_ambient_light_poller(self):
-        ambient_light_poller = poller.AmbientLightPoller(
-            self.mock_local_clock, POLL_INTERVAL, self.mock_sensor,
-            self.mock_store)
-        self.mock_local_clock.now.return_value = TIMESTAMP_A
-        self.mock_local_clock.wait.side_effect = (
-            lambda _: self.clock_wait_event.set())
-        self.mock_sensor.ambient_light.return_value = 50.0
+        with contextlib.closing(
+                poller.AmbientLightPoller(
+                    self.mock_local_clock, POLL_INTERVAL, self.mock_sensor,
+                    self.mock_store)) as ambient_light_poller:
+            self.mock_local_clock.now.return_value = TIMESTAMP_A
+            self.mock_local_clock.wait.side_effect = (
+                lambda _: self.clock_wait_event.set())
+            self.mock_sensor.ambient_light.return_value = 50.0
 
-        ambient_light_poller.start_polling_async()
-        self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            ambient_light_poller.start_polling_async()
+            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
         self.mock_store.store_ambient_light.assert_called_with(TIMESTAMP_A,
                                                                50.0)
         self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
@@ -88,50 +93,56 @@ class WateringEventPollerTest(unittest.TestCase):
         self.mock_soil_moisture_store = mock.Mock()
 
     def test_watering_event_poller_when_pump_run(self):
-        watering_event_poller = poller.WateringEventPoller(
-            self.mock_local_clock, POLL_INTERVAL, self.mock_pump_manager,
-            self.mock_watering_event_store, self.mock_soil_moisture_store)
-        self.mock_local_clock.now.return_value = TIMESTAMP_A
-        self.mock_local_clock.wait.side_effect = (
-            lambda _: self.clock_wait_event.set())
-        self.mock_pump_manager.pump_if_needed.return_value = 200
-        self.mock_soil_moisture_store.latest_soil_moisture.return_value = 100
+        with contextlib.closing(
+                poller.WateringEventPoller(
+                    self.mock_local_clock, POLL_INTERVAL,
+                    self.mock_pump_manager, self.mock_watering_event_store,
+                    self.mock_soil_moisture_store)) as watering_event_poller:
+            self.mock_local_clock.now.return_value = TIMESTAMP_A
+            self.mock_local_clock.wait.side_effect = (
+                lambda _: self.clock_wait_event.set())
+            self.mock_pump_manager.pump_if_needed.return_value = 200
+            self.mock_soil_moisture_store.latest_soil_moisture.return_value = 100
 
-        watering_event_poller.start_polling_async()
-        self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            watering_event_poller.start_polling_async()
+            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
         self.mock_watering_event_store.store_water_pumped.assert_called_with(
             TIMESTAMP_A, 200)
         self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
         self.mock_pump_manager.pump_if_needed.assert_called_with(100)
 
     def test_watering_event_poller_when_pump_not_run(self):
-        watering_event_poller = poller.WateringEventPoller(
-            self.mock_local_clock, POLL_INTERVAL, self.mock_pump_manager,
-            self.mock_watering_event_store, self.mock_soil_moisture_store)
-        self.mock_local_clock.wait.side_effect = (
-            lambda _: self.clock_wait_event.set())
-        self.mock_pump_manager.pump_if_needed.return_value = 0
-        self.mock_soil_moisture_store.latest_soil_moisture.return_value = 500
+        with contextlib.closing(
+                poller.WateringEventPoller(
+                    self.mock_local_clock, POLL_INTERVAL,
+                    self.mock_pump_manager, self.mock_watering_event_store,
+                    self.mock_soil_moisture_store)) as watering_event_poller:
+            self.mock_local_clock.wait.side_effect = (
+                lambda _: self.clock_wait_event.set())
+            self.mock_pump_manager.pump_if_needed.return_value = 0
+            self.mock_soil_moisture_store.latest_soil_moisture.return_value = 500
 
-        watering_event_poller.start_polling_async()
-        self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            watering_event_poller.start_polling_async()
+            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
         self.assertFalse(
             self.mock_watering_event_store.store_water_pumped.called)
         self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
         self.mock_pump_manager.pump_if_needed.assert_called_with(500)
 
     def test_watering_event_poller_when_moisture_is_None(self):
-        watering_event_poller = poller.WateringEventPoller(
-            self.mock_local_clock, POLL_INTERVAL, self.mock_pump_manager,
-            self.mock_watering_event_store, self.mock_soil_moisture_store)
-        self.mock_local_clock.wait.side_effect = (
-            lambda _: self.clock_wait_event.set())
-        self.mock_soil_moisture_store.latest_soil_moisture.return_value = None
+        with contextlib.closing(
+                poller.WateringEventPoller(
+                    self.mock_local_clock, POLL_INTERVAL,
+                    self.mock_pump_manager, self.mock_watering_event_store,
+                    self.mock_soil_moisture_store)) as watering_event_poller:
+            self.mock_local_clock.wait.side_effect = (
+                lambda _: self.clock_wait_event.set())
+            self.mock_soil_moisture_store.latest_soil_moisture.return_value = None
 
-        watering_event_poller.start_polling_async()
-        self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
-        self.assertFalse(
-            self.mock_watering_event_store.store_water_pumped.called)
+            watering_event_poller.start_polling_async()
+            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            self.assertFalse(
+                self.mock_watering_event_store.store_water_pumped.called)
         self.assertFalse(self.mock_pump_manager.pump_if_needed.called)
         self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
 
@@ -142,10 +153,11 @@ class CameraPollerTest(unittest.TestCase):
         clock_wait_event = threading.Event()
         mock_local_clock = mock.Mock()
         mock_camera_manager = mock.Mock()
-        camera_poller = poller.CameraPoller(mock_local_clock, POLL_INTERVAL,
-                                            mock_camera_manager)
-        mock_local_clock.wait.side_effect = lambda _: clock_wait_event.set()
+        with contextlib.closing(
+                poller.CameraPoller(mock_local_clock, POLL_INTERVAL,
+                                    mock_camera_manager)) as camera_poller:
+            mock_local_clock.wait.side_effect = lambda _: clock_wait_event.set()
 
-        camera_poller.start_polling_async()
-        clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            camera_poller.start_polling_async()
+            clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
         mock_camera_manager.save_photo.assert_called()


### PR DESCRIPTION
The pollers originally were designed without a way of stopping the background
polling thread. In practice, we probably don't really need a way of closing
the thread, but in unit tests, we need a way of killing the background thread
when the test ends, otherwise the tests spawn a bunch of threads that never
stop running.

I'm not sure why the existing tests never triggered this problem, but when we
change the pollers to be record queue based, I'm seeing this issue, so fixing
the tests ahead of that change.