### PR TITLE
Fixing the default value of the wiring config path

### DIFF
--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
         '-c',
         '--config_file',
         help='Wiring config file',
-        default='wiring_config.ini')
+        default='greenpithumb/wiring_config.ini')
     parser.add_argument(
         '-s',
         '--sleep_window',


### PR DESCRIPTION
Changing the wiring config path so that it agrees with what's specified in the
README and shares a folder with greenpithumb.db