### PR TITLE
Refactoring method names in DbStore classes

### DIFF
--- a/greenpithumb/db_store.py
+++ b/greenpithumb/db_store.py
@@ -126,7 +126,7 @@ class DbStoreBase(object):
 class SoilMoistureStore(DbStoreBase):
     """Stores and retrieves timestamp and soil moisture readings."""
 
-    def store_soil_moisture(self, soil_moisture_record):
+    def insert(self, soil_moisture_record):
         """Inserts moisture and timestamp info into an SQLite database.
 
         Args:
@@ -137,7 +137,7 @@ class SoilMoistureStore(DbStoreBase):
             soil_moisture_record.soil_moisture))
         self._connection.commit()
 
-    def latest_soil_moisture(self):
+    def get_latest(self):
         """Returns the most recent soil moisture reading."""
         query = '''SELECT soil_moisture FROM soil_moisture
                 ORDER BY timestamp DESC
@@ -150,7 +150,7 @@ class SoilMoistureStore(DbStoreBase):
         else:
             return results[0][0]
 
-    def retrieve_soil_moisture(self):
+    def get(self):
         """Retrieves timestamp and soil moisture readings.
 
         Returns:
@@ -167,7 +167,7 @@ class SoilMoistureStore(DbStoreBase):
 class AmbientLightStore(DbStoreBase):
     """Stores timestamp and ambient light readings."""
 
-    def store_ambient_light(self, ambient_light_record):
+    def insert(self, ambient_light_record):
         """Inserts ambient light and timestamp info into an SQLite database.
 
         Args:
@@ -178,7 +178,7 @@ class AmbientLightStore(DbStoreBase):
             ambient_light_record.ambient_light))
         self._connection.commit()
 
-    def retrieve_ambient_light(self):
+    def get(self):
         """Retrieves timestamp and ambient light readings.
 
         Returns:
@@ -195,7 +195,7 @@ class AmbientLightStore(DbStoreBase):
 class HumidityStore(DbStoreBase):
     """Stores timestamp and ambient humidity readings."""
 
-    def store_humidity(self, humidity_record):
+    def insert(self, humidity_record):
         """Inserts humidity and timestamp info into an SQLite database.
 
         Args:
@@ -206,7 +206,7 @@ class HumidityStore(DbStoreBase):
                               humidity_record.humidity))
         self._connection.commit()
 
-    def retrieve_humidity(self):
+    def get(self):
         """Retrieves timestamp and relative humidity readings.
 
         Returns:
@@ -223,7 +223,7 @@ class HumidityStore(DbStoreBase):
 class TemperatureStore(DbStoreBase):
     """Stores timestamp and ambient temperature readings."""
 
-    def store_temperature(self, temperature_record):
+    def insert(self, temperature_record):
         """Inserts temperature and timestamp info into an SQLite database.
 
         Args:
@@ -234,7 +234,7 @@ class TemperatureStore(DbStoreBase):
             temperature_record.temperature))
         self._connection.commit()
 
-    def retrieve_temperature(self):
+    def get(self):
         """Retrieves timestamp and temperature(C) readings.
 
         Returns:
@@ -251,7 +251,7 @@ class TemperatureStore(DbStoreBase):
 class WateringEventStore(DbStoreBase):
     """Stores timestamp and volume of water pumped to plant."""
 
-    def store_water_pumped(self, watering_event_record):
+    def insert(self, watering_event_record):
         """Inserts water volume and timestamp info into an SQLite database.
 
         Args:
@@ -262,7 +262,7 @@ class WateringEventStore(DbStoreBase):
             watering_event_record.water_pumped))
         self._connection.commit()
 
-    def retrieve_water_pumped(self):
+    def get(self):
         """Retrieves timestamp and volume of water pumped(in mL).
 
         Returns:

--- a/greenpithumb/record_processor.py
+++ b/greenpithumb/record_processor.py
@@ -33,15 +33,15 @@ class RecordProcessor(object):
         """
         record = self._record_queue.get()
         if isinstance(record, db_store.SoilMoistureRecord):
-            self._soil_moisture_store.store_soil_moisture(record)
+            self._soil_moisture_store.insert(record)
         elif isinstance(record, db_store.AmbientLightRecord):
-            self._ambient_light_store.store_ambient_light(record)
+            self._ambient_light_store.insert(record)
         elif isinstance(record, db_store.HumidityRecord):
-            self._humidity_store.store_humidity(record)
+            self._humidity_store.insert(record)
         elif isinstance(record, db_store.TemperatureRecord):
-            self._temperature_store.store_temperature(record)
+            self._temperature_store.insert(record)
         elif isinstance(record, db_store.WateringEventRecord):
-            self._watering_event_store.store_water_pumped(record)
+            self._watering_event_store.insert(record)
         else:
             raise UnsupportedRecordError('Unrecognized record type: %s' %
                                          str(record))

--- a/tests/test_db_store.py
+++ b/tests/test_db_store.py
@@ -64,38 +64,38 @@ class StoreClassesTest(unittest.TestCase):
         self.mock_connection = mock.Mock()
         self.mock_connection.cursor.return_value = self.mock_cursor
 
-    def test_store_soil_moisture(self):
+    def test_insert_soil_moisture(self):
         """Should insert timestamp and moisture level into database."""
         record = db_store.SoilMoistureRecord(
             timestamp=datetime.datetime(
                 2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
             soil_moisture=300)
         store = db_store.SoilMoistureStore(self.mock_connection)
-        store.store_soil_moisture(record)
+        store.insert(record)
         self.mock_cursor.execute.assert_called_once_with(
             'INSERT INTO soil_moisture VALUES (?, ?)', (
                 '2016-07-23T10:51:09.928000+00:00', 300))
         self.mock_connection.commit.assert_called_once()
 
-    def test_latest_soil_moisture(self):
+    def test_get_latest_soil_moisture(self):
         store = db_store.SoilMoistureStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = [(300,)]
-        moisture = store.latest_soil_moisture()
+        moisture = store.get_latest()
         self.assertEqual(300, moisture)
 
-    def test_latest_soil_moisture_empty_database(self):
+    def test_get_latest_soil_moisture_empty_database(self):
         store = db_store.SoilMoistureStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = []
-        moisture = store.latest_soil_moisture()
+        moisture = store.get_latest()
         self.assertIsNone(moisture)
 
-    def test_retrieve_soil_moisture(self):
+    def test_get_soil_moisture(self):
         store = db_store.SoilMoistureStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = [
             ('2016-07-23 10:51:09.928000-05:00', 300),
             ('2016-07-23 10:52:09.928000-05:00', 400)
         ]
-        soil_moisture_data = store.retrieve_soil_moisture()
+        soil_moisture_data = store.get()
         soil_moisture_data.sort(
             key=lambda SoilMoistureRecord: SoilMoistureRecord.timestamp)
 
@@ -110,32 +110,32 @@ class StoreClassesTest(unittest.TestCase):
                 2016, 7, 23, 10, 52, 9, 928000, tzinfo=UTC_MINUS_5))
         self.assertEqual(soil_moisture_data[1].soil_moisture, 400)
 
-    def test_retrieve_soil_moisture_empty_database(self):
+    def test_get_soil_moisture_empty_database(self):
         store = db_store.SoilMoistureStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = []
-        soil_moisture_data = store.retrieve_soil_moisture()
+        soil_moisture_data = store.get()
         self.assertEqual(soil_moisture_data, [])
 
-    def test_store_ambient_light(self):
+    def test_insert_ambient_light(self):
         """Should insert timestamp and ambient light into database."""
         ambient_light_record = db_store.AmbientLightRecord(
             timestamp=datetime.datetime(
                 2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
             ambient_light=50.0)
         store = db_store.AmbientLightStore(self.mock_connection)
-        store.store_ambient_light(ambient_light_record)
+        store.insert(ambient_light_record)
         self.mock_cursor.execute.assert_called_once_with(
             'INSERT INTO ambient_light VALUES (?, ?)', (
                 '2016-07-23T10:51:09.928000+00:00', 50.0))
         self.mock_connection.commit.assert_called_once()
 
-    def test_retrieve_ambient_light(self):
+    def test_get_ambient_light(self):
         store = db_store.AmbientLightStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = [
             ('2016-07-23 10:51:09.928000-05:00', 300),
             ('2016-07-23 10:52:09.928000-05:00', 400)
         ]
-        ambient_light_data = store.retrieve_ambient_light()
+        ambient_light_data = store.get()
         ambient_light_data.sort(
             key=lambda AmbientLightRecord: AmbientLightRecord.timestamp)
 
@@ -150,32 +150,32 @@ class StoreClassesTest(unittest.TestCase):
                 2016, 7, 23, 10, 52, 9, 928000, tzinfo=UTC_MINUS_5))
         self.assertEqual(ambient_light_data[1].ambient_light, 400)
 
-    def test_retrieve_ambient_light_empty_database(self):
+    def test_get_ambient_light_empty_database(self):
         store = db_store.AmbientLightStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = []
-        ambient_light_data = store.retrieve_ambient_light()
+        ambient_light_data = store.get()
         self.assertEqual(ambient_light_data, [])
 
-    def test_store_humidity(self):
+    def test_insert_humidity(self):
         """Should insert timestamp and humidity level into database."""
         humidity_record = db_store.HumidityRecord(
             timestamp=datetime.datetime(
                 2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
             humidity=50.0)
         store = db_store.HumidityStore(self.mock_connection)
-        store.store_humidity(humidity_record)
+        store.insert(humidity_record)
         self.mock_cursor.execute.assert_called_once_with(
             'INSERT INTO ambient_humidity VALUES (?, ?)',
             ('2016-07-23T10:51:09.928000+00:00', 50.0))
         self.mock_connection.commit.assert_called_once()
 
-    def test_retrieve_humidity(self):
+    def test_get_humidity(self):
         store = db_store.HumidityStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = [
             ('2016-07-23 10:51:09.928000-05:00', 50),
             ('2016-07-23 10:52:09.928000-05:00', 51)
         ]
-        humidity_data = store.retrieve_humidity()
+        humidity_data = store.get()
         humidity_data.sort(key=lambda HumidityRecord: HumidityRecord.timestamp)
 
         self.assertEqual(
@@ -189,32 +189,32 @@ class StoreClassesTest(unittest.TestCase):
                 2016, 7, 23, 10, 52, 9, 928000, tzinfo=UTC_MINUS_5))
         self.assertEqual(humidity_data[1].humidity, 51)
 
-    def test_retrieve_humidity_empty_database(self):
+    def test_get_humidity_empty_database(self):
         store = db_store.HumidityStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = []
-        humidity_data = store.retrieve_humidity()
+        humidity_data = store.get()
         self.assertEqual(humidity_data, [])
 
-    def test_store_temperature(self):
+    def test_insert_temperature(self):
         """Should insert timestamp and temperature into database."""
         temperature_record = db_store.TemperatureRecord(
             timestamp=datetime.datetime(
                 2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
             temperature=21.1)
         store = db_store.TemperatureStore(self.mock_connection)
-        store.store_temperature(temperature_record)
+        store.insert(temperature_record)
         self.mock_cursor.execute.assert_called_once_with(
             'INSERT INTO temperature VALUES (?, ?)',
             ('2016-07-23T10:51:09.928000+00:00', 21.1))
         self.mock_connection.commit.assert_called_once()
 
-    def test_retrieve_temperature(self):
+    def test_get_temperature(self):
         store = db_store.TemperatureStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = [
             ('2016-07-23 10:51:09.928000-05:00', 21.0),
             ('2016-07-23 10:52:09.928000-05:00', 21.5)
         ]
-        temperature_data = store.retrieve_temperature()
+        temperature_data = store.get()
         temperature_data.sort(
             key=lambda TemperatureRecord: TemperatureRecord.timestamp)
 
@@ -229,32 +229,32 @@ class StoreClassesTest(unittest.TestCase):
                 2016, 7, 23, 10, 52, 9, 928000, tzinfo=UTC_MINUS_5))
         self.assertEqual(temperature_data[1].temperature, 21.5)
 
-    def test_retrieve_temperature_empty_database(self):
+    def test_get_temperature_empty_database(self):
         store = db_store.TemperatureStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = []
-        temperature_data = store.retrieve_temperature()
+        temperature_data = store.get()
         self.assertEqual(temperature_data, [])
 
-    def test_store_water_pumped(self):
+    def test_insert_water_pumped(self):
         """Should insert timestamp and volume of water pumped into database."""
         watering_event_record = db_store.WateringEventRecord(
             timestamp=datetime.datetime(
                 2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
             water_pumped=200.0)
         store = db_store.WateringEventStore(self.mock_connection)
-        store.store_water_pumped(watering_event_record)
+        store.insert(watering_event_record)
         self.mock_cursor.execute.assert_called_once_with(
             'INSERT INTO watering_events VALUES (?, ?)', (
                 '2016-07-23T10:51:09.928000+00:00', 200.0))
         self.mock_connection.commit.assert_called_once()
 
-    def test_retrieve_water_pumped(self):
+    def test_get_water_pumped(self):
         store = db_store.WateringEventStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = [
             ('2016-07-23 10:51:09.928000-05:00', 300),
             ('2016-07-23 10:52:09.928000-05:00', 301)
         ]
-        watering_event_data = store.retrieve_water_pumped()
+        watering_event_data = store.get()
         watering_event_data.sort(
             key=lambda WaterintEventRecord: WaterintEventRecord.timestamp)
 
@@ -269,8 +269,8 @@ class StoreClassesTest(unittest.TestCase):
                 2016, 7, 23, 10, 52, 9, 928000, tzinfo=UTC_MINUS_5))
         self.assertEqual(watering_event_data[1].water_pumped, 301)
 
-    def test_retrieve_water_pumped_empty_database(self):
+    def test_get_water_pumped_empty_database(self):
         store = db_store.WateringEventStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = []
-        watering_event_data = store.retrieve_water_pumped()
+        watering_event_data = store.get()
         self.assertEqual(watering_event_data, [])

--- a/tests/test_record_processor.py
+++ b/tests/test_record_processor.py
@@ -33,8 +33,7 @@ class RecordProcessorTest(unittest.TestCase):
             soil_moisture=300)
         self.record_queue.put(record)
         self.processor.process_next_record()
-        self.mock_soil_moisture_store.store_soil_moisture.assert_called_with(
-            record)
+        self.mock_soil_moisture_store.insert.assert_called_with(record)
 
     def test_process_ambient_light_record(self):
         record = db_store.AmbientLightRecord(
@@ -43,8 +42,7 @@ class RecordProcessorTest(unittest.TestCase):
             ambient_light=29.2)
         self.record_queue.put(record)
         self.processor.process_next_record()
-        self.mock_ambient_light_store.store_ambient_light.assert_called_with(
-            record)
+        self.mock_ambient_light_store.insert.assert_called_with(record)
 
     def test_process_humidity_record(self):
         record = db_store.HumidityRecord(
@@ -53,7 +51,7 @@ class RecordProcessorTest(unittest.TestCase):
             humidity=184.5)
         self.record_queue.put(record)
         self.processor.process_next_record()
-        self.mock_humidity_store.store_humidity.assert_called_with(record)
+        self.mock_humidity_store.insert.assert_called_with(record)
 
     def test_process_temperature_record(self):
         record = db_store.TemperatureRecord(
@@ -62,7 +60,7 @@ class RecordProcessorTest(unittest.TestCase):
             temperature=32.9)
         self.record_queue.put(record)
         self.processor.process_next_record()
-        self.mock_temperature_store.store_temperature.assert_called_with(record)
+        self.mock_temperature_store.insert.assert_called_with(record)
 
     def test_process_watering_event_record(self):
         record = db_store.WateringEventRecord(
@@ -71,8 +69,7 @@ class RecordProcessorTest(unittest.TestCase):
             water_pumped=15.6)
         self.record_queue.put(record)
         self.processor.process_next_record()
-        self.mock_watering_event_store.store_water_pumped.assert_called_with(
-            record)
+        self.mock_watering_event_store.insert.assert_called_with(record)
 
     def test_rejects_unsupported_record(self):
         record = 'dummy invalid record'


### PR DESCRIPTION
The calling semantics of the DbStore classes are a bit redundant because we
end up with calls like 'temperature_store.store_temperature'. The class name
gives the type, so we don't have to repeat it in the method. I think if we do
this, it opens up the door to some refactoring around managing multiple
db store instances of different types.