### PR TITLE
Merging SoilMoisturePoller and WateringEventPoller

### DIFF
--- a/greenpithumb/db_store.py
+++ b/greenpithumb/db_store.py
@@ -137,19 +137,6 @@ class SoilMoistureStore(DbStoreBase):
             soil_moisture_record.soil_moisture))
         self._connection.commit()
 
-    def get_latest(self):
-        """Returns the most recent soil moisture reading."""
-        query = '''SELECT soil_moisture FROM soil_moisture
-                ORDER BY timestamp DESC
-                LIMIT 1;'''
-
-        self._cursor.execute(query)
-        results = self._cursor.fetchall()
-        if not results:
-            return None
-        else:
-            return results[0][0]
-
     def get(self):
         """Retrieves timestamp and soil moisture readings.
 

--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -43,17 +43,26 @@ def make_sensor_pollers(poll_interval, wiring_config, record_queue):
     poller_factory = poller.SensorPollerFactory(local_clock, poll_interval,
                                                 record_queue)
 
+    # Temporary PumpManager class until we finish the real class.
+    class DummyPumpManager(object):
+
+        def pump_if_needed(self, _):
+            return 0
+
+    pump_manager = DummyPumpManager()
+
     return [
         poller_factory.create_temperature_poller(
             temperature_sensor.TemperatureSensor(local_dht11)),
         poller_factory.create_humidity_poller(
             humidity_sensor.HumiditySensor(local_dht11)),
-        poller_factory.create_moisture_poller(
+        poller_factory.create_soil_watering_poller(
             moisture_sensor.MoistureSensor(
                 adc,
                 pi_io.IO(GPIO), wiring_config.adc_channels.soil_moisture_sensor,
                 wiring_config.gpio_pins.soil_moisture_1,
-                wiring_config.gpio_pins.soil_moisture_2, local_clock)),
+                wiring_config.gpio_pins.soil_moisture_2, local_clock),
+            pump_manager),
         poller_factory.create_ambient_light_poller(
             light_sensor.LightSensor(adc,
                                      wiring_config.adc_channels.light_sensor)),

--- a/tests/test_db_store.py
+++ b/tests/test_db_store.py
@@ -77,18 +77,6 @@ class StoreClassesTest(unittest.TestCase):
                 '2016-07-23T10:51:09.928000+00:00', 300))
         self.mock_connection.commit.assert_called_once()
 
-    def test_get_latest_soil_moisture(self):
-        store = db_store.SoilMoistureStore(self.mock_connection)
-        self.mock_cursor.fetchall.return_value = [(300,)]
-        moisture = store.get_latest()
-        self.assertEqual(300, moisture)
-
-    def test_get_latest_soil_moisture_empty_database(self):
-        store = db_store.SoilMoistureStore(self.mock_connection)
-        self.mock_cursor.fetchall.return_value = []
-        moisture = store.get_latest()
-        self.assertIsNone(moisture)
-
     def test_get_soil_moisture(self):
         store = db_store.SoilMoistureStore(self.mock_connection)
         self.mock_cursor.fetchall.return_value = [


### PR DESCRIPTION
It turns out things are a lot simpler when we combine the poller for checking
soil moisture with the poller responsible for running the pump based on soil
moisture. Now, the SoilWateringPoller can check soil moisture, store the
record in the DB, but then use the same reading to determine if it needs to
pump water.

Because of this, we can get rid of the get_latest method on SoilMoistureStore,
which is nice because now all the DbStore classes have the exact same interface
and we can delete the old SoilMoisturePoller and not add much code to the
former WateringEventPoller.