### PR TITLE
Refactoring pollers

### DIFF
--- a/greenpithumb/poller.py
+++ b/greenpithumb/poller.py
@@ -7,165 +7,138 @@ logger = logging.getLogger(__name__)
 
 
 class SensorPollerFactory(object):
-    """Factory to simplify the semantics of creating pollers."""
+    """Factory for creating sensor poller objects."""
 
     def __init__(self, local_clock, poll_interval, record_queue):
+        """Create a new SensorPollerFactory instance.
+
+        Args:
+            local_clock: A local time zone clock interface.
+            poll_interval: An int of how often the data should be polled for,
+                in seconds.
+            record_queue: Queue on which to place database records.
+        """
         self._local_clock = local_clock
         self._poll_interval = poll_interval
         self._record_queue = record_queue
 
     def create_temperature_poller(self, temperature_sensor):
-        return TemperaturePoller(self._local_clock, self._poll_interval,
-                                 temperature_sensor, self._record_queue)
+        return _SensorPoller(
+            _TemperaturePollWorker(self._local_clock, self._poll_interval,
+                                   self._record_queue, temperature_sensor))
 
     def create_humidity_poller(self, humidity_sensor):
-        return HumidityPoller(self._local_clock, self._poll_interval,
-                              humidity_sensor, self._record_queue)
-
-    def create_soil_watering_poller(self, moisture_sensor, pump_manager):
-        return SoilWateringPoller(self._local_clock, self._poll_interval,
-                                  moisture_sensor, pump_manager,
-                                  self._record_queue)
+        return _SensorPoller(
+            _HumidityPollWorker(self._local_clock, self._poll_interval,
+                                self._record_queue, humidity_sensor))
 
     def create_ambient_light_poller(self, light_sensor):
-        return AmbientLightPoller(self._local_clock, self._poll_interval,
-                                  light_sensor, self._record_queue)
+        return _SensorPoller(
+            _AmbientLightPollWorker(self._local_clock, self._poll_interval,
+                                    self._record_queue, light_sensor))
+
+    def create_soil_watering_poller(self, moisture_sensor, pump_manager):
+        return _SensorPoller(
+            _SoilWateringPollWorker(self._local_clock, self._poll_interval,
+                                    self._record_queue, moisture_sensor,
+                                    pump_manager))
+
+    def create_camera_poller(self, camera_manager):
+        return _SensorPoller(
+            _CameraPollWorker(self._local_clock, self._poll_interval,
+                              self._record_queue, camera_manager))
 
 
-class SensorPollerBase(object):
-    """Base class for sensor polling."""
+class _SensorPollWorkerBase(object):
+    """Base class for sensor poll worker.
 
-    def __init__(self, local_clock, poll_interval):
-        """Creates a new SensorPollerBase object for polling sensors.
+    The poll worker is the class that handles all the work and context for the
+    background polling thread.
+    """
+
+    def __init__(self, local_clock, poll_interval, record_queue, sensor):
+        """Create a new _SensorPollWorkerBase instance
 
         Args:
             local_clock: A local time zone clock interface.
-            poll_interval: An int of how often the sensor should be polled, in
-                seconds.
+            poll_interval: An int of how often the data should be polled for,
+                in seconds.
+            record_queue: Queue on which to place database records.
+            sensor: A sensor to poll for status. The particular type of sensor
+                will vary depending on the poll worker subclass.
         """
         self._local_clock = local_clock
         self._poll_interval = poll_interval
-        self._closed = threading.Event()
+        self._record_queue = record_queue
+        self._sensor = sensor
+        self._stopped = threading.Event()
 
-    def _poll(self):
+    def poll(self):
         """Polls at a fixed interval until caller calls close()."""
         logger.info('polling starting for %s', self.__class__.__name__)
-        while not self._closed.is_set():
+        while not self._stopped.is_set():
             self._poll_once()
             self._local_clock.wait(self._poll_interval)
         logger.info('polling terminating for %s', self.__class__.__name__)
 
-    def start_polling_async(self):
-        """Starts a new thread to begin polling."""
-        t = threading.Thread(target=self._poll)
-        t.setDaemon(True)
-        t.start()
-
-    def close(self):
-        """Stops polling."""
-        self._closed.set()
+    def stop(self):
+        """End worker polling."""
+        self._stopped.set()
 
 
-class TemperaturePoller(SensorPollerBase):
+class _TemperaturePollWorker(_SensorPollWorkerBase):
     """Polls a temperature sensor and stores the readings."""
-
-    def __init__(self, local_clock, poll_interval, temperature_sensor,
-                 record_queue):
-        """Creates a new TemperaturePoller object.
-
-        Args:
-            local_clock: A local time zone clock interface.
-            poll_interval: An int of how often the sensor should be polled, in
-                seconds.
-            temperature_sensor: An interface for reading the temperature.
-            record_queue: Queue on which to place temperature records for
-              storage.
-        """
-        super(TemperaturePoller, self).__init__(local_clock, poll_interval)
-        self._temperature_sensor = temperature_sensor
-        self._record_queue = record_queue
 
     def _poll_once(self):
         """Polls for current ambient temperature and queues DB record."""
-        temperature = self._temperature_sensor.temperature()
+        temperature = self._sensor.temperature()
         self._record_queue.put(
             db_store.TemperatureRecord(self._local_clock.now(), temperature))
 
 
-class HumidityPoller(SensorPollerBase):
+class _HumidityPollWorker(_SensorPollWorkerBase):
     """Polls a humidity sensor and stores the readings."""
-
-    def __init__(self, local_clock, poll_interval, humidity_sensor,
-                 record_queue):
-        """Creates a new HumidityPoller object.
-
-        Args:
-            local_clock: A local time zone clock interface.
-            poll_interval: An int of how often the sensor should be polled, in
-                seconds.
-            humidity_sensor: An interface for reading the humidity.
-            record_queue: Queue on which to place humidity records for storage.
-        """
-        super(HumidityPoller, self).__init__(local_clock, poll_interval)
-        self._humidity_sensor = humidity_sensor
-        self._record_queue = record_queue
 
     def _poll_once(self):
         """Polls for and stores current relative humidity."""
-        humidity = self._humidity_sensor.humidity()
+        humidity = self._sensor.humidity()
         self._record_queue.put(
             db_store.HumidityRecord(self._local_clock.now(), humidity))
 
 
-class AmbientLightPoller(SensorPollerBase):
+class _AmbientLightPollWorker(_SensorPollWorkerBase):
     """Polls an ambient light sensor and stores the readings."""
 
-    def __init__(self, local_clock, poll_interval, light_sensor, record_queue):
-        """Creates a new AmbientLightPoller object.
-
-        Args:
-            local_clock: A local time zone clock interface.
-            poll_interval: An int of how often the sensor should be polled, in
-                seconds.
-            light_sensor: An interface for reading the ambient light level.
-            record_queue: Queue on which to place ambient light records for
-              storage.
-        """
-        super(AmbientLightPoller, self).__init__(local_clock, poll_interval)
-        self._light_sensor = light_sensor
-        self._record_queue = record_queue
-
     def _poll_once(self):
-        ambient_light = self._light_sensor.ambient_light()
+        ambient_light = self._sensor.ambient_light()
         self._record_queue.put(
             db_store.AmbientLightRecord(self._local_clock.now(), ambient_light))
 
 
-class SoilWateringPoller(SensorPollerBase):
+class _SoilWateringPollWorker(_SensorPollWorkerBase):
     """Polls for and records watering event data.
 
     Polls soil moisture sensor and oversees a water pump based to add water when
     the moisture drops too low. Records both soil moisture and watering events.
     """
 
-    def __init__(self, local_clock, poll_interval, soil_moisture_sensor,
-                 pump_manager, record_queue):
+    def __init__(self, local_clock, poll_interval, record_queue,
+                 soil_moisture_sensor, pump_manager):
         """Creates a new SoilWateringPoller object.
 
         Args:
             local_clock: A local time zone clock interface.
             poll_interval: An int of how often the data should be polled for,
                 in seconds.
+            record_queue: Queue on which to place soil moisture records and
+                watering event records for storage.
             soil_moisture_sensor: An interface for reading the soil moisture
                 level.
             pump_manager: An interface to manage a water pump.
-            record_queue: Queue on which to place soil moisture records and
-                watering event records for storage.
         """
-        super(SoilWateringPoller, self).__init__(local_clock, poll_interval)
+        super(_SoilWateringPollWorker, self).__init__(
+            local_clock, poll_interval, record_queue, soil_moisture_sensor)
         self._pump_manager = pump_manager
-        self._soil_moisture_sensor = soil_moisture_sensor
-        self._record_queue = record_queue
 
     def _poll_once(self):
         """Polls soil moisture and adds water if moisture is too low.
@@ -174,7 +147,7 @@ class SoilWateringPoller(SensorPollerBase):
         current soil moisture level, checks if the pump needs to run, and if so,
         runs the pump and records the watering event.
         """
-        soil_moisture = self._soil_moisture_sensor.moisture()
+        soil_moisture = self._sensor.moisture()
         self._record_queue.put(
             db_store.SoilMoistureRecord(self._local_clock.now(), soil_moisture))
         ml_pumped = self._pump_manager.pump_if_needed(soil_moisture)
@@ -184,21 +157,30 @@ class SoilWateringPoller(SensorPollerBase):
                                              ml_pumped))
 
 
-class CameraPoller(SensorPollerBase):
+class _CameraPollWorker(_SensorPollWorkerBase):
     """Captures and stores pictures pictures from a camera."""
-
-    def __init__(self, local_clock, poll_interval, camera_manager):
-        """Creates a new CameraPoller object.
-
-        Args:
-            local_clock: A local time zone clock interface.
-            poll_interval: An int of how often the images should be captured,
-                in seconds.
-            camera_manager: An interface for capturing images.
-        """
-        super(CameraPoller, self).__init__(local_clock, poll_interval)
-        self._camera_manager = camera_manager
 
     def _poll_once(self):
         """Captures and stores an image."""
-        self._camera_manager.save_photo()
+        self._sensor.save_photo()
+
+
+class _SensorPoller(object):
+    """Spawns and manages poll workers in background threads."""
+
+    def __init__(self, poll_worker):
+        """Creates a new _SensorPoller object for polling sensors.
+
+        Args:
+            poll_worker: Worker object that handles the polling work.
+        """
+        self._worker = poll_worker
+
+    def start_polling_async(self):
+        """Starts a new thread to begin polling."""
+        t = threading.Thread(target=self._worker.poll)
+        t.start()
+
+    def close(self):
+        """Stops polling."""
+        self._worker.stop()


### PR DESCRIPTION
The goal of the refactoring is to fix two problems:
1. SensorPollBase has a design flaw in that it runs in the main thread, but
 holds instance data that belongs to in the background thread.
 This is error-prone because if any of the member variables are not thread-safe
 we it creates concurrency issues if both threads touch the members at the same
 time. We should redesign it so that the variables that the background thread uses
 are separate from the variables that the main thread and kept in private members
 so they're inaccessible outside the thread.
2. There are two ways of instantiating the pollers: through the
 SensorPollerFactory and by instantiating the objects directly. Offering an
 API with multiple ways of doing the same thing is messy, so we're making
 the classes private so that the factory is the only way clients can create
 them. We also rewrite the unit tests to test through the factory so that the
 unit tests are an accurate reflection of how the caller uses the APIs.