### PR TITLE
Changing polling to occur on time boundaries

### DIFF
--- a/greenpithumb/poller.py
+++ b/greenpithumb/poller.py
@@ -60,7 +60,7 @@ class SensorPollerFactory(object):
 def _datetime_to_unix_time(dt):
     """Converts a datetime into seconds since UNIX epoch."""
     unix_epoch = datetime.datetime(year=1970, month=1, day=1, tzinfo=pytz.utc)
-    return (dt - unix_epoch).total_seconds()
+    return int((dt - unix_epoch).total_seconds())
 
 
 def _round_up_to_multiple(value, multiple):
@@ -128,7 +128,7 @@ class _SensorPollWorkerBase(object):
         """
         next_poll_time = _round_up_to_multiple(self._unix_now(),
                                                self._poll_interval)
-        if next_poll_time and (next_poll_time == last_poll_time):
+        if last_poll_time and (next_poll_time == last_poll_time):
             next_poll_time += self._poll_interval
         return next_poll_time
 

--- a/greenpithumb/poller.py
+++ b/greenpithumb/poller.py
@@ -1,9 +1,17 @@
+import datetime
 import logging
 import threading
+
+import pytz
 
 import db_store
 
 logger = logging.getLogger(__name__)
+
+# Number of seconds to idle between checks for whether a poller needs to poll or
+# a poller needs to stop (note that this is NOT the total time a poller sleeps
+# between polls).
+_IDLE_SECONDS = 0.5
 
 
 class SensorPollerFactory(object):
@@ -49,6 +57,22 @@ class SensorPollerFactory(object):
                               self._record_queue, camera_manager))
 
 
+def _datetime_to_unix_time(dt):
+    """Converts a datetime into seconds since UNIX epoch."""
+    unix_epoch = datetime.datetime(year=1970, month=1, day=1, tzinfo=pytz.utc)
+    return (dt - unix_epoch).total_seconds()
+
+
+def _round_up_to_multiple(value, multiple):
+    """Rounds an integer value up to a multiple specified."""
+    mod = value % multiple
+    # Value is already an exact multiple, so return the original value.
+    if mod == 0:
+        return value
+    # Round up to next multiple
+    return (value - mod) + multiple
+
+
 class _SensorPollWorkerBase(object):
     """Base class for sensor poll worker.
 
@@ -73,12 +97,54 @@ class _SensorPollWorkerBase(object):
         self._sensor = sensor
         self._stopped = threading.Event()
 
+    def _unix_now(self):
+        return _datetime_to_unix_time(self._local_clock.now())
+
+    def _wait_until_unix_time(self, target_unix_time):
+        """Waits until the target time arrives or the worker is stopped.
+
+        Args:
+            target_unix_time: UNIX time to wait until.
+        """
+        logger.info('%s is waiting %d seconds until next poll',
+                    self.__class__.__name__,
+                    target_unix_time - self._unix_now())
+        while not self._is_stopped() and (self._unix_now() < target_unix_time):
+            self._local_clock.wait(_IDLE_SECONDS)
+
+    def _next_poll_time(self, last_poll_time):
+        """Calculates time of next poll in UNIX time.
+
+        Calculates time of next poll so that it is a multiple of
+        self._poll_interval. If the next multiple is the same as the last poll
+        time, returns a poll time that is the current time + one poll interval.
+
+        Args:
+            last_poll_time: The UNIX time of the last poll or None if this is
+                the first poll.
+
+        Returns:
+            UNIX time of next scheduled poll.
+        """
+        next_poll_time = _round_up_to_multiple(self._unix_now(),
+                                               self._poll_interval)
+        if next_poll_time and (next_poll_time == last_poll_time):
+            next_poll_time += self._poll_interval
+        return next_poll_time
+
+    def _is_stopped(self):
+        return self._stopped.is_set()
+
     def poll(self):
-        """Polls at a fixed interval until caller calls close()."""
+        """Polls at a fixed interval until caller calls stop()."""
         logger.info('polling starting for %s', self.__class__.__name__)
-        while not self._stopped.is_set():
+        next_poll_time = self._next_poll_time(last_poll_time=None)
+        while True:
+            self._wait_until_unix_time(next_poll_time)
+            if self._is_stopped():
+                break
             self._poll_once()
-            self._local_clock.wait(self._poll_interval)
+            next_poll_time = self._next_poll_time(last_poll_time=next_poll_time)
         logger.info('polling terminating for %s', self.__class__.__name__)
 
     def stop(self):
@@ -179,6 +245,7 @@ class _SensorPoller(object):
     def start_polling_async(self):
         """Starts a new thread to begin polling."""
         t = threading.Thread(target=self._worker.poll)
+        t.setDaemon(True)
         t.start()
 
     def close(self):

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -10,91 +10,97 @@ import pytz
 from greenpithumb import db_store
 from greenpithumb import poller
 
-TEST_TIMEOUT_SECONDS = 3.0
+TEST_TIMEOUT_SECONDS = 1.5
+POLL_INTERVAL = 15
 TIMESTAMP_A = datetime.datetime(2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc)
-POLL_INTERVAL = 1
+TIMESTAMP_B = datetime.datetime(2016, 7, 23, 10, 51, 15, 0, tzinfo=pytz.utc)
 
 
-class PollerClassesTest(unittest.TestCase):
+class PollerTest(unittest.TestCase):
 
     def setUp(self):
         self.clock_wait_event = threading.Event()
         self.mock_local_clock = mock.Mock()
+        self.mock_local_clock.wait.side_effect = (
+            lambda _: self.clock_wait_event.set())
         self.mock_sensor = mock.Mock()
         self.mock_store = mock.Mock()
         self.record_queue = Queue.Queue()
         self.factory = poller.SensorPollerFactory(
             self.mock_local_clock, POLL_INTERVAL, self.record_queue)
 
+    def block_until_clock_wait_call(self):
+        """Blocks until the clock's wait method is called or test times out."""
+        self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+        self.clock_wait_event.clear()
+
+
+class SimplePollerClassesTest(PollerTest):
+
     def test_temperature_poller(self):
         with contextlib.closing(
                 self.factory.create_temperature_poller(
                     self.mock_sensor)) as temperature_poller:
             self.mock_local_clock.now.return_value = TIMESTAMP_A
-            self.mock_local_clock.wait.side_effect = (
-                lambda _: self.clock_wait_event.set())
             self.mock_sensor.temperature.return_value = 21.0
 
             temperature_poller.start_polling_async()
-            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            self.block_until_clock_wait_call()
+            self.mock_local_clock.now.return_value = TIMESTAMP_B
+            self.block_until_clock_wait_call()
 
         self.assertEqual(
             db_store.TemperatureRecord(
-                timestamp=TIMESTAMP_A, temperature=21.0),
+                timestamp=TIMESTAMP_B, temperature=21.0),
             self.record_queue.get(block=True, timeout=TEST_TIMEOUT_SECONDS))
-        self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
+        # Should be no more items in the queue.
+        self.assertTrue(self.record_queue.empty())
 
     def test_humidity_poller(self):
         with contextlib.closing(
                 self.factory.create_humidity_poller(
                     self.mock_sensor)) as humidity_poller:
             self.mock_local_clock.now.return_value = TIMESTAMP_A
-            self.mock_local_clock.wait.side_effect = (
-                lambda _: self.clock_wait_event.set())
             self.mock_sensor.humidity.return_value = 50.0
 
             humidity_poller.start_polling_async()
-            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            self.block_until_clock_wait_call()
+            self.mock_local_clock.now.return_value = TIMESTAMP_B
+            self.block_until_clock_wait_call()
 
         self.assertEqual(
             db_store.HumidityRecord(
-                timestamp=TIMESTAMP_A, humidity=50.0),
+                timestamp=TIMESTAMP_B, humidity=50.0),
             self.record_queue.get(block=True, timeout=TEST_TIMEOUT_SECONDS))
-        self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
+        # Should be no more items in the queue.
+        self.assertTrue(self.record_queue.empty())
 
     def test_ambient_light_poller(self):
         with contextlib.closing(
                 self.factory.create_ambient_light_poller(
                     self.mock_sensor)) as ambient_light_poller:
             self.mock_local_clock.now.return_value = TIMESTAMP_A
-            self.mock_local_clock.wait.side_effect = (
-                lambda _: self.clock_wait_event.set())
             self.mock_sensor.ambient_light.return_value = 50.0
 
             ambient_light_poller.start_polling_async()
-            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            self.block_until_clock_wait_call()
+            self.mock_local_clock.now.return_value = TIMESTAMP_B
+            self.block_until_clock_wait_call()
 
         self.assertEqual(
             db_store.AmbientLightRecord(
-                timestamp=TIMESTAMP_A, ambient_light=50.0),
+                timestamp=TIMESTAMP_B, ambient_light=50.0),
             self.record_queue.get(block=True, timeout=TEST_TIMEOUT_SECONDS))
-        self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
+        # Should be no more items in the queue.
+        self.assertTrue(self.record_queue.empty())
 
 
-class SoilWateringPollerTest(unittest.TestCase):
+class SoilWateringPollerTest(PollerTest):
 
     def setUp(self):
-        self.clock_wait_event = threading.Event()
-        self.mock_local_clock = mock.Mock()
+        super(SoilWateringPollerTest, self).setUp()
         self.mock_pump_manager = mock.Mock()
         self.mock_soil_moisture_sensor = mock.Mock()
-        self.record_queue = Queue.Queue()
-        self.factory = poller.SensorPollerFactory(
-            self.mock_local_clock, POLL_INTERVAL, self.record_queue)
-
-    def _stop_poller(self, poller):
-        poller.close()
-        self.clock_wait_event.set()
 
     def test_soil_watering_poller_when_pump_run(self):
         with contextlib.closing(
@@ -102,27 +108,27 @@ class SoilWateringPollerTest(unittest.TestCase):
                     self.mock_soil_moisture_sensor,
                     self.mock_pump_manager)) as soil_watering_poller:
             self.mock_local_clock.now.return_value = TIMESTAMP_A
-            self.mock_local_clock.wait.side_effect = (
-                lambda _: self._stop_poller(soil_watering_poller))
             self.mock_pump_manager.pump_if_needed.return_value = 200
             self.mock_soil_moisture_sensor.moisture.return_value = 100
 
             soil_watering_poller.start_polling_async()
-            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            self.block_until_clock_wait_call()
+            self.mock_local_clock.now.return_value = TIMESTAMP_B
+            self.block_until_clock_wait_call()
+
         records_expected = [
             db_store.SoilMoistureRecord(
-                timestamp=TIMESTAMP_A, soil_moisture=100),
+                timestamp=TIMESTAMP_B, soil_moisture=100),
             db_store.WateringEventRecord(
-                timestamp=TIMESTAMP_A, water_pumped=200.0)
+                timestamp=TIMESTAMP_B, water_pumped=200.0)
         ]
         records_actual = [
             self.record_queue.get(block=True, timeout=TEST_TIMEOUT_SECONDS),
             self.record_queue.get(block=True, timeout=TEST_TIMEOUT_SECONDS)
         ]
+        self.assertItemsEqual(records_expected, records_actual)
         # Should be no more items in the queue.
         self.assertTrue(self.record_queue.empty())
-        self.assertItemsEqual(records_expected, records_actual)
-        self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
         self.mock_pump_manager.pump_if_needed.assert_called_with(100)
 
     def test_soil_watering_poller_when_pump_not_run(self):
@@ -131,36 +137,41 @@ class SoilWateringPollerTest(unittest.TestCase):
                     self.mock_soil_moisture_sensor,
                     self.mock_pump_manager)) as soil_watering_poller:
             self.mock_local_clock.now.return_value = TIMESTAMP_A
-            self.mock_local_clock.wait.side_effect = (
-                lambda _: self._stop_poller(soil_watering_poller))
             self.mock_pump_manager.pump_if_needed.return_value = 0
             self.mock_soil_moisture_sensor.moisture.return_value = 500
 
             soil_watering_poller.start_polling_async()
-            self.clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
+            self.block_until_clock_wait_call()
+            self.mock_local_clock.now.return_value = TIMESTAMP_B
+            self.block_until_clock_wait_call()
+
         self.assertEqual(
             db_store.SoilMoistureRecord(
-                timestamp=TIMESTAMP_A, soil_moisture=500),
+                timestamp=TIMESTAMP_B, soil_moisture=500),
             self.record_queue.get(block=True, timeout=TEST_TIMEOUT_SECONDS))
         # Should be no more items in the queue.
         self.assertTrue(self.record_queue.empty())
-        self.mock_local_clock.wait.assert_called_with(POLL_INTERVAL)
         self.mock_pump_manager.pump_if_needed.assert_called_with(500)
 
 
-class CameraPollerTest(unittest.TestCase):
+class CameraPollerTest(PollerTest):
+
+    def setUp(self):
+        super(CameraPollerTest, self).setUp()
+        self.mock_camera_manager = mock.Mock()
 
     def test_camera_poller(self):
-        clock_wait_event = threading.Event()
-        mock_local_clock = mock.Mock()
-        mock_camera_manager = mock.Mock()
-        factory = poller.SensorPollerFactory(
-            mock_local_clock, POLL_INTERVAL, record_queue=None)
         with contextlib.closing(
-                factory.create_camera_poller(
-                    mock_camera_manager)) as camera_poller:
-            mock_local_clock.wait.side_effect = lambda _: clock_wait_event.set()
+                self.factory.create_camera_poller(
+                    self.mock_camera_manager)) as camera_poller:
+            self.mock_local_clock.now.return_value = TIMESTAMP_A
 
             camera_poller.start_polling_async()
-            clock_wait_event.wait(TEST_TIMEOUT_SECONDS)
-            mock_camera_manager.save_photo.assert_called()
+            self.block_until_clock_wait_call()
+            self.mock_local_clock.now.return_value = TIMESTAMP_B
+            self.block_until_clock_wait_call()
+
+        self.mock_camera_manager.save_photo.assert_called()
+        # Should be nothing items in the queue because CameraPoller does not
+        # create database records.
+        self.assertTrue(self.record_queue.empty())

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -13,6 +13,7 @@ from greenpithumb import poller
 TEST_TIMEOUT_SECONDS = 1.5
 POLL_INTERVAL = 15
 TIMESTAMP_A = datetime.datetime(2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc)
+# TIMESTAMP_B is on the poll interval boundary immediately after TIMESTAMP_A.
 TIMESTAMP_B = datetime.datetime(2016, 7, 23, 10, 51, 15, 0, tzinfo=pytz.utc)
 
 


### PR DESCRIPTION
In the current implementation, each sensor starts reading immediately, then
polls every n seconds. This means that the readings depend on when the
greenpithumb started, so if a user runs greenpithumb on two different days
with two different start times, the reading timestamps won't be aligned.

By changing the polling time to happen on interval boundaries, we get aligned
readings no matter when we start the greenpithumb process.

As a side effect, this doesn't solve the uninterruptible process issue (#99)
but it should make it easier to fix since we're getting rid of most of the
threads that block forever until some event happens.