### PR TITLE
Adding a thread-safe wrapper around the ADC

### DIFF
--- a/greenpithumb/adc_thread_safe.py
+++ b/greenpithumb/adc_thread_safe.py
@@ -1,0 +1,27 @@
+import threading
+
+
+class Adc(object):
+    """Thread-safe wrapper around an ADC object."""
+
+    def __init__(self, adc):
+        """Create a new Adc instance
+
+        Args:
+            adc: The raw ADC which this class makes thread-safe by synchronizing
+                its read calls.
+        """
+        self._adc = adc
+        self._lock = threading.Lock()
+
+    def read_adc(self, adc_number):
+        """Read a value from the ADC
+
+        Args:
+            adc_number: ADC channel to read.
+
+        Returns:
+            The value read from the given ADC channel (as a float).
+        """
+        with self._lock:
+            return self._adc.read_adc(adc_number)

--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -7,6 +7,7 @@ import Adafruit_DHT
 import Adafruit_MCP3008
 import RPi.GPIO as GPIO
 
+import adc_thread_safe
 import clock
 import db_store
 import dht11
@@ -31,11 +32,12 @@ def make_sensor_pollers(poll_interval, wiring_config, record_queue):
     # * CS/SHDN -> CS
     # * DOUT -> MISO
     # * DIN -> MOSI
-    adc = Adafruit_MCP3008.MCP3008(
-        clk=wiring_config.gpio_pins.mcp3008_clk,
-        cs=wiring_config.gpio_pins.mcp3008_cs_shdn,
-        miso=wiring_config.gpio_pins.mcp3008_dout,
-        mosi=wiring_config.gpio_pins.mcp3008_din)
+    adc = adc_thread_safe.Adc(
+        Adafruit_MCP3008.MCP3008(
+            clk=wiring_config.gpio_pins.mcp3008_clk,
+            cs=wiring_config.gpio_pins.mcp3008_cs_shdn,
+            miso=wiring_config.gpio_pins.mcp3008_dout,
+            mosi=wiring_config.gpio_pins.mcp3008_din))
     local_dht11 = dht11.CachingDHT11(
         lambda: Adafruit_DHT.read_retry(Adafruit_DHT.DHT11, wiring_config.gpio_pins.dht11),
         local_clock)

--- a/tests/test_adc_thread_safe.py
+++ b/tests/test_adc_thread_safe.py
@@ -1,0 +1,37 @@
+import threading
+import time
+import unittest
+
+import mock
+
+from greenpithumb import adc_thread_safe
+
+
+class AdcTest(unittest.TestCase):
+
+    def setUp(self):
+        self.counter = 0
+
+    def increment_counter(self, amount):
+        # Increment counter in a deliberately inefficient way to invite a race
+        # condition if this is called by more than one thread at once.
+        for i in range(amount):
+            current = self.counter
+            time.sleep(0.01)
+            self.counter = current + 1
+
+    def test_read_adc_is_thread_safe(self):
+        raw_adc = mock.Mock()
+        raw_adc.read_adc.side_effect = lambda x: self.increment_counter(10)
+        adc = adc_thread_safe.Adc(raw_adc)
+        threads = []
+        # Spawn several threads to call read_adc concurrently to see if they
+        # trigger a race condition.
+        for _ in range(5):
+            threads.append(threading.Thread(target=lambda: adc.read_adc(0)))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        # Check that the threads incremented the counter correctly.
+        self.assertEqual(10 * 5, self.counter)


### PR DESCRIPTION
Multiple threads share access to the ADC instance, so we need a way to make
it thread-safe.