### PR TITLE
Changing RecordProcessor to return success

### DIFF
--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -117,8 +117,8 @@ def main(args):
             for current_poller in pollers:
                 current_poller.start_polling_async()
             while True:
-                record_processor.try_process_next_record()
-                time.sleep(0.1)
+                if not record_processor.try_process_next_record():
+                    time.sleep(0.1)
         except KeyboardInterrupt:
             logger.info('Caught keyboard interrupt. Exiting.')
         finally:

--- a/greenpithumb/record_processor.py
+++ b/greenpithumb/record_processor.py
@@ -31,11 +31,19 @@ class RecordProcessor(object):
 
         Must be called from the same thread from which the database connections
         were created.
+
+        Returns:
+            True if it processed a record, False if the queue contained no
+            records.
+
+        Raises:
+            UnsupportedRecordError if the queue contains an unexpected record
+                type.
         """
         try:
             record = self._record_queue.get_nowait()
         except Queue.Empty:
-            return
+            return False
 
         if isinstance(record, db_store.SoilMoistureRecord):
             self._soil_moisture_store.insert(record)
@@ -50,3 +58,4 @@ class RecordProcessor(object):
         else:
             raise UnsupportedRecordError('Unrecognized record type: %s' %
                                          str(record))
+        return True

--- a/tests/test_record_processor.py
+++ b/tests/test_record_processor.py
@@ -26,8 +26,8 @@ class RecordProcessorTest(unittest.TestCase):
             temperature_store=self.mock_temperature_store,
             watering_event_store=self.mock_watering_event_store)
 
-    def test_process_empty_queue_does_not_hang_or_raise_error(self):
-        self.processor.try_process_next_record()
+    def test_process_empty_queue_returns_False(self):
+        self.assertFalse(self.processor.try_process_next_record())
 
     def test_process_soil_moisture_record(self):
         record = db_store.SoilMoistureRecord(
@@ -35,7 +35,7 @@ class RecordProcessorTest(unittest.TestCase):
                 2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
             soil_moisture=300)
         self.record_queue.put(record)
-        self.processor.try_process_next_record()
+        self.assertTrue(self.processor.try_process_next_record())
         self.mock_soil_moisture_store.insert.assert_called_with(record)
 
     def test_process_ambient_light_record(self):
@@ -44,7 +44,7 @@ class RecordProcessorTest(unittest.TestCase):
                 2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
             ambient_light=29.2)
         self.record_queue.put(record)
-        self.processor.try_process_next_record()
+        self.assertTrue(self.processor.try_process_next_record())
         self.mock_ambient_light_store.insert.assert_called_with(record)
 
     def test_process_humidity_record(self):
@@ -53,7 +53,7 @@ class RecordProcessorTest(unittest.TestCase):
                 2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
             humidity=184.5)
         self.record_queue.put(record)
-        self.processor.try_process_next_record()
+        self.assertTrue(self.processor.try_process_next_record())
         self.mock_humidity_store.insert.assert_called_with(record)
 
     def test_process_temperature_record(self):
@@ -62,7 +62,7 @@ class RecordProcessorTest(unittest.TestCase):
                 2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
             temperature=32.9)
         self.record_queue.put(record)
-        self.processor.try_process_next_record()
+        self.assertTrue(self.processor.try_process_next_record())
         self.mock_temperature_store.insert.assert_called_with(record)
 
     def test_process_watering_event_record(self):
@@ -71,7 +71,7 @@ class RecordProcessorTest(unittest.TestCase):
                 2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc),
             water_pumped=15.6)
         self.record_queue.put(record)
-        self.processor.try_process_next_record()
+        self.assertTrue(self.processor.try_process_next_record())
         self.mock_watering_event_store.insert.assert_called_with(record)
 
     def test_rejects_unsupported_record(self):


### PR DESCRIPTION
This allows the main script to know if there was anything in the queue. The
main script can then process records rapidly if any are in the queue, but
will sleep briefly if the queue is empty.