### PR TITLE
Removing pip install picamera

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ python setup.py install
 cd ..
 git clone https://github.com/JeetShetty/GreenPiThumb.git
 cd GreenPiThumb
-sudo pip install picamera
 sudo pip install -r requirements.txt
 cp greenpithumb/wiring_config.ini.example greenpithumb/wiring_config.ini
 ```


### PR DESCRIPTION
I forgot it's actually installed with apt-get a few lines up as
python-picamera.