### PR TITLE
Changing camera to save hi res files and use UTC time

### DIFF
--- a/greenpithumb/camera_manager.py
+++ b/greenpithumb/camera_manager.py
@@ -3,31 +3,34 @@ import os
 
 logger = logging.getLogger(__name__)
 
+# Format of filename to write for camera image file (assumes timestamp is in
+# UTC), as YYYY-MM-DDTHH:MM:SSZ (ISO 8601 format)
+_FILENAME_FORMAT = '%Y-%m-%dT%H%M%SZ.jpg'
+
 
 class CameraManager(object):
     """Captures and saves photos to the filesystem."""
 
-    def __init__(self, image_path, local_clock, camera):
+    def __init__(self, image_path, clock, camera):
         """Creates a new camera manager instance.
 
         Args:
             image_path: Path name of the folder where images will be stored.
-            local_clock: Local clock interface.
+            clock: Clock interface.
             camera: Camera interface.
         """
         if not os.path.exists(image_path):
             os.makedirs(image_path)
         self._image_path = image_path
-        self._local_clock = local_clock
+        self._clock = clock
         self._camera = camera
 
     def save_photo(self):
         """Captures an image from the camera and saves it to the filesystem."""
-        filename = self._local_clock.now().isoformat().replace(':', '-') + (
-            '.jpg')
-        full_path = os.path.join(self._image_path, filename)
-        self._camera.capture(full_path)
-        logger.info('saved new photo to %s', full_path)
+        path = os.path.join(self._image_path,
+                            self._clock.now().strftime(_FILENAME_FORMAT))
+        self._camera.capture(path)
+        logger.info('saved new photo to %s', path)
 
     def close(self):
         """Closes the camera.

--- a/greenpithumb/camera_manager.py
+++ b/greenpithumb/camera_manager.py
@@ -4,8 +4,8 @@ import os
 logger = logging.getLogger(__name__)
 
 # Format of filename to write for camera image file (assumes timestamp is in
-# UTC), as YYYY-MM-DDTHH:MM:SSZ (ISO 8601 format)
-_FILENAME_FORMAT = '%Y-%m-%dT%H%M%SZ.jpg'
+# UTC), as YYYY-MM-DDTHH:MMZ (minutes-level precision).
+_FILENAME_FORMAT = '%Y-%m-%dT%H%MZ.jpg'
 
 
 class CameraManager(object):

--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -75,12 +75,14 @@ def make_sensor_pollers(poll_interval, wiring_config, record_queue,
 
 
 def make_camera_poller(photo_interval, image_path, record_queue):
-    local_clock = clock.LocalClock()
-    poller_factory = poller.SensorPollerFactory(local_clock, photo_interval,
+    utc_clock = clock.Clock()
+    poller_factory = poller.SensorPollerFactory(utc_clock, photo_interval,
                                                 record_queue)
     return poller_factory.create_camera_poller(
-        camera_manager.CameraManager(image_path, local_clock,
-                                     picamera.PiCamera()))
+        camera_manager.CameraManager(
+            image_path,
+            utc_clock,
+            picamera.PiCamera(resolution=picamera.PiCamera.MAX_RESOLUTION)))
 
 
 def read_wiring_config(config_filename):

--- a/tests/test_camera_manager.py
+++ b/tests/test_camera_manager.py
@@ -25,7 +25,7 @@ class TestCameraManager(unittest.TestCase):
                                              mock_camera)) as manager:
             manager.save_photo()
         mock_camera.capture.assert_called_once_with(
-            'C:/Users/Jeet/2016-07-23T105109Z.jpg')
+            'C:/Users/Jeet/2016-07-23T1051Z.jpg')
         mock_exists.assert_called_once_with(image_path)
         mock_makedirs.assert_not_called()
         mock_camera.close.assert_called()

--- a/tests/test_camera_manager.py
+++ b/tests/test_camera_manager.py
@@ -25,7 +25,7 @@ class TestCameraManager(unittest.TestCase):
                                              mock_camera)) as manager:
             manager.save_photo()
         mock_camera.capture.assert_called_once_with(
-            'C:/Users/Jeet/2016-07-23T10-51-09.928000+00-00.jpg')
+            'C:/Users/Jeet/2016-07-23T105109Z.jpg')
         mock_exists.assert_called_once_with(image_path)
         mock_makedirs.assert_not_called()
         mock_camera.close.assert_called()


### PR DESCRIPTION
Changing camera poller to use UTC time and a string timestamp format to match
the database timestamp format.

Changing the camera's resolution to be the max resolution.