### PR TITLE
Getting rid of seconds-level precision

### DIFF
--- a/greenpithumb/db_store.py
+++ b/greenpithumb/db_store.py
@@ -54,8 +54,8 @@ CREATE TABLE watering_events
 """
 
 # Format to store timestamps to database (assumes timestamp is in UTC) in format
-# of YYYY-MM-DDTHH:MM:SSZ (ISO 8601 format)
-_TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+# of YYYY-MM-DDTHH:MMZ.
+_TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%MZ'
 
 
 def _timestamp_to_utc(timestamp):

--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -150,14 +150,14 @@ if __name__ == '__main__':
         '-p',
         '--poll_interval',
         type=float,
-        help='Number of seconds between each sensor poll',
-        default=(15 * 60))
+        help='Number of minutes between each sensor poll',
+        default=15)
     parser.add_argument(
         '-t',
         '--photo_interval',
         type=float,
-        help='Number of seconds between each camera photo',
-        default=(4 * 60 * 60))
+        help='Number of minutes between each camera photo',
+        default=(4 * 60))
     parser.add_argument(
         '-c',
         '--config_file',

--- a/greenpithumb/poller.py
+++ b/greenpithumb/poller.py
@@ -8,6 +8,7 @@ import db_store
 
 logger = logging.getLogger(__name__)
 
+_SECONDS_PER_MINUTE = 60
 # Number of seconds to idle between checks for whether a poller needs to poll or
 # a poller needs to stop (note that this is NOT the total time a poller sleeps
 # between polls).
@@ -23,7 +24,7 @@ class SensorPollerFactory(object):
         Args:
             clock: A clock interface.
             poll_interval: An int of how often the data should be polled for,
-                in seconds.
+                in minutes.
             record_queue: Queue on which to place database records.
         """
         self._clock = clock
@@ -86,7 +87,7 @@ class _SensorPollWorkerBase(object):
         Args:
             clock: A clock interface.
             poll_interval: An int of how often the data should be polled for,
-                in seconds.
+                in minutes.
             record_queue: Queue on which to place database records.
             sensor: A sensor to poll for status. The particular type of sensor
                 will vary depending on the poll worker subclass.
@@ -129,7 +130,7 @@ class _SensorPollWorkerBase(object):
         next_poll_time = _round_up_to_multiple(self._unix_now(),
                                                self._poll_interval)
         if last_poll_time and (next_poll_time == last_poll_time):
-            next_poll_time += self._poll_interval
+            next_poll_time += (self._poll_interval * _SECONDS_PER_MINUTE)
         return next_poll_time
 
     def _is_stopped(self):
@@ -195,7 +196,7 @@ class _SoilWateringPollWorker(_SensorPollWorkerBase):
         Args:
             clock: A clock interface.
             poll_interval: An int of how often the data should be polled for,
-                in seconds.
+                in minutes.
             record_queue: Queue on which to place soil moisture records and
                 watering event records for storage.
             soil_moisture_sensor: An interface for reading the soil moisture

--- a/tests/test_db_store.py
+++ b/tests/test_db_store.py
@@ -45,15 +45,15 @@ class OpenOrCreateTest(unittest.TestCase):
             cursor = connection.cursor()
             # Insertions into all tables should work after initialization.
             cursor.execute('INSERT INTO temperature VALUES (?, ?)',
-                           ('2016-07-23T10:51:09Z', 98.6))
+                           ('2016-07-23T10:51Z', 98.6))
             cursor.execute('INSERT INTO ambient_humidity VALUES (?, ?)',
-                           ('2016-07-23T10:51:09Z', 93.7))
+                           ('2016-07-23T10:51Z', 93.7))
             cursor.execute('INSERT INTO soil_moisture VALUES (?, ?)',
-                           ('2016-07-23T10:51:09Z', 57))
+                           ('2016-07-23T10:51Z', 57))
             cursor.execute('INSERT INTO ambient_light VALUES (?, ?)',
-                           ('2016-07-23T10:51:09Z', 75.2))
+                           ('2016-07-23T10:51Z', 75.2))
             cursor.execute('INSERT INTO watering_events VALUES (?, ?)',
-                           ('2016-07-23T10:51:09Z', 258.9))
+                           ('2016-07-23T10:51Z', 258.9))
             connection.commit()
 
 
@@ -68,12 +68,12 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and moisture level into database."""
         record = db_store.SoilMoistureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
             soil_moisture=300)
         store = db_store.SoilMoistureStore(self.mock_connection)
         store.insert(record)
         self.mock_cursor.execute.assert_called_once_with(
-            'INSERT INTO soil_moisture VALUES (?, ?)', ('2016-07-23T10:51:09Z',
+            'INSERT INTO soil_moisture VALUES (?, ?)', ('2016-07-23T10:51Z',
                                                         300))
         self.mock_connection.commit.assert_called_once()
 
@@ -81,19 +81,19 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and moisture level into database."""
         record = db_store.SoilMoistureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
             soil_moisture=300)
         store = db_store.SoilMoistureStore(self.mock_connection)
         store.insert(record)
         self.mock_cursor.execute.assert_called_once_with(
-            'INSERT INTO soil_moisture VALUES (?, ?)', ('2016-07-23T15:51:09Z',
+            'INSERT INTO soil_moisture VALUES (?, ?)', ('2016-07-23T15:51Z',
                                                         300))
         self.mock_connection.commit.assert_called_once()
 
     def test_get_soil_moisture(self):
         store = db_store.SoilMoistureStore(self.mock_connection)
-        self.mock_cursor.fetchall.return_value = [('2016-07-23T10:51:09Z', 300),
-                                                  ('2016-07-23T10:52:09Z', 400)]
+        self.mock_cursor.fetchall.return_value = [('2016-07-23T10:51Z', 300),
+                                                  ('2016-07-23T10:52Z', 400)]
         soil_moisture_data = store.get()
         soil_moisture_data.sort(
             key=lambda SoilMoistureRecord: SoilMoistureRecord.timestamp)
@@ -101,12 +101,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             soil_moisture_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
         self.assertEqual(soil_moisture_data[0].soil_moisture, 300)
         self.assertEqual(
             soil_moisture_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, 9, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
         self.assertEqual(soil_moisture_data[1].soil_moisture, 400)
 
     def test_get_soil_moisture_empty_database(self):
@@ -119,12 +119,12 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and ambient light into database."""
         ambient_light_record = db_store.AmbientLightRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
             ambient_light=50.0)
         store = db_store.AmbientLightStore(self.mock_connection)
         store.insert(ambient_light_record)
         self.mock_cursor.execute.assert_called_once_with(
-            'INSERT INTO ambient_light VALUES (?, ?)', ('2016-07-23T10:51:09Z',
+            'INSERT INTO ambient_light VALUES (?, ?)', ('2016-07-23T10:51Z',
                                                         50.0))
         self.mock_connection.commit.assert_called_once()
 
@@ -132,19 +132,19 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and ambient light into database."""
         ambient_light_record = db_store.AmbientLightRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
             ambient_light=50.0)
         store = db_store.AmbientLightStore(self.mock_connection)
         store.insert(ambient_light_record)
         self.mock_cursor.execute.assert_called_once_with(
-            'INSERT INTO ambient_light VALUES (?, ?)', ('2016-07-23T15:51:09Z',
+            'INSERT INTO ambient_light VALUES (?, ?)', ('2016-07-23T15:51Z',
                                                         50.0))
         self.mock_connection.commit.assert_called_once()
 
     def test_get_ambient_light(self):
         store = db_store.AmbientLightStore(self.mock_connection)
-        self.mock_cursor.fetchall.return_value = [('2016-07-23T10:51:09Z', 300),
-                                                  ('2016-07-23T10:52:09Z', 400)]
+        self.mock_cursor.fetchall.return_value = [('2016-07-23T10:51Z', 300),
+                                                  ('2016-07-23T10:52Z', 400)]
         ambient_light_data = store.get()
         ambient_light_data.sort(
             key=lambda AmbientLightRecord: AmbientLightRecord.timestamp)
@@ -152,12 +152,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             ambient_light_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
         self.assertEqual(ambient_light_data[0].ambient_light, 300)
         self.assertEqual(
             ambient_light_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, 9, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
         self.assertEqual(ambient_light_data[1].ambient_light, 400)
 
     def test_get_ambient_light_empty_database(self):
@@ -170,44 +170,44 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and humidity level into database."""
         humidity_record = db_store.HumidityRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
             humidity=50.0)
         store = db_store.HumidityStore(self.mock_connection)
         store.insert(humidity_record)
         self.mock_cursor.execute.assert_called_once_with(
             'INSERT INTO ambient_humidity VALUES (?, ?)',
-            ('2016-07-23T10:51:09Z', 50.0))
+            ('2016-07-23T10:51Z', 50.0))
         self.mock_connection.commit.assert_called_once()
 
     def test_insert_humidity_with_non_utc_time(self):
         """Should insert timestamp and humidity level into database."""
         humidity_record = db_store.HumidityRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
             humidity=50.0)
         store = db_store.HumidityStore(self.mock_connection)
         store.insert(humidity_record)
         self.mock_cursor.execute.assert_called_once_with(
             'INSERT INTO ambient_humidity VALUES (?, ?)',
-            ('2016-07-23T15:51:09Z', 50.0))
+            ('2016-07-23T15:51Z', 50.0))
         self.mock_connection.commit.assert_called_once()
 
     def test_get_humidity(self):
         store = db_store.HumidityStore(self.mock_connection)
-        self.mock_cursor.fetchall.return_value = [('2016-07-23T10:51:09Z', 50),
-                                                  ('2016-07-23T10:52:09Z', 51)]
+        self.mock_cursor.fetchall.return_value = [('2016-07-23T10:51Z', 50),
+                                                  ('2016-07-23T10:52Z', 51)]
         humidity_data = store.get()
         humidity_data.sort(key=lambda HumidityRecord: HumidityRecord.timestamp)
 
         self.assertEqual(
             humidity_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
         self.assertEqual(humidity_data[0].humidity, 50)
         self.assertEqual(
             humidity_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, 9, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
         self.assertEqual(humidity_data[1].humidity, 51)
 
     def test_get_humidity_empty_database(self):
@@ -220,33 +220,32 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and temperature into database."""
         temperature_record = db_store.TemperatureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
             temperature=21.1)
         store = db_store.TemperatureStore(self.mock_connection)
         store.insert(temperature_record)
         self.mock_cursor.execute.assert_called_once_with(
             'INSERT INTO temperature VALUES (?, ?)',
-            ('2016-07-23T10:51:09Z', 21.1))
+            ('2016-07-23T10:51Z', 21.1))
         self.mock_connection.commit.assert_called_once()
 
     def test_insert_temperature_with_non_utc_time(self):
         """Should insert timestamp and temperature into database."""
         temperature_record = db_store.TemperatureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
             temperature=21.1)
         store = db_store.TemperatureStore(self.mock_connection)
         store.insert(temperature_record)
         self.mock_cursor.execute.assert_called_once_with(
             'INSERT INTO temperature VALUES (?, ?)',
-            ('2016-07-23T15:51:09Z', 21.1))
+            ('2016-07-23T15:51Z', 21.1))
         self.mock_connection.commit.assert_called_once()
 
     def test_get_temperature(self):
         store = db_store.TemperatureStore(self.mock_connection)
-        self.mock_cursor.fetchall.return_value = [
-            ('2016-07-23T10:51:09Z', 21.0), ('2016-07-23T10:52:09Z', 21.5)
-        ]
+        self.mock_cursor.fetchall.return_value = [('2016-07-23T10:51Z', 21.0),
+                                                  ('2016-07-23T10:52Z', 21.5)]
         temperature_data = store.get()
         temperature_data.sort(
             key=lambda TemperatureRecord: TemperatureRecord.timestamp)
@@ -254,12 +253,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             temperature_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
         self.assertEqual(temperature_data[0].temperature, 21.0)
         self.assertEqual(
             temperature_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, 9, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
         self.assertEqual(temperature_data[1].temperature, 21.5)
 
     def test_get_temperature_empty_database(self):
@@ -272,32 +271,32 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and volume of water pumped into database."""
         watering_event_record = db_store.WateringEventRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
             water_pumped=200.0)
         store = db_store.WateringEventStore(self.mock_connection)
         store.insert(watering_event_record)
         self.mock_cursor.execute.assert_called_once_with(
-            'INSERT INTO watering_events VALUES (?, ?)', (
-                '2016-07-23T10:51:09Z', 200.0))
+            'INSERT INTO watering_events VALUES (?, ?)', ('2016-07-23T10:51Z',
+                                                          200.0))
         self.mock_connection.commit.assert_called_once()
 
     def test_insert_water_pumped_with_non_utc_time(self):
         """Should insert timestamp and volume of water pumped into database."""
         watering_event_record = db_store.WateringEventRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
             water_pumped=200.0)
         store = db_store.WateringEventStore(self.mock_connection)
         store.insert(watering_event_record)
         self.mock_cursor.execute.assert_called_once_with(
-            'INSERT INTO watering_events VALUES (?, ?)', (
-                '2016-07-23T15:51:09Z', 200.0))
+            'INSERT INTO watering_events VALUES (?, ?)', ('2016-07-23T15:51Z',
+                                                          200.0))
         self.mock_connection.commit.assert_called_once()
 
     def test_get_water_pumped(self):
         store = db_store.WateringEventStore(self.mock_connection)
-        self.mock_cursor.fetchall.return_value = [('2016-07-23T10:51:09Z', 300),
-                                                  ('2016-07-23T10:52:09Z', 301)]
+        self.mock_cursor.fetchall.return_value = [('2016-07-23T10:51Z', 300),
+                                                  ('2016-07-23T10:52Z', 301)]
         watering_event_data = store.get()
         watering_event_data.sort(
             key=lambda WaterintEventRecord: WaterintEventRecord.timestamp)
@@ -305,12 +304,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             watering_event_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, 9, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
         self.assertEqual(watering_event_data[0].water_pumped, 300)
         self.assertEqual(
             watering_event_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, 9, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
         self.assertEqual(watering_event_data[1].water_pumped, 301)
 
     def test_get_water_pumped_empty_database(self):

--- a/tests/test_db_store.py
+++ b/tests/test_db_store.py
@@ -68,7 +68,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and moisture level into database."""
         record = db_store.SoilMoistureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, tzinfo=pytz.utc),
             soil_moisture=300)
         store = db_store.SoilMoistureStore(self.mock_connection)
         store.insert(record)
@@ -81,7 +81,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and moisture level into database."""
         record = db_store.SoilMoistureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, tzinfo=UTC_MINUS_5),
             soil_moisture=300)
         store = db_store.SoilMoistureStore(self.mock_connection)
         store.insert(record)
@@ -101,12 +101,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             soil_moisture_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, tzinfo=pytz.utc))
         self.assertEqual(soil_moisture_data[0].soil_moisture, 300)
         self.assertEqual(
             soil_moisture_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, tzinfo=pytz.utc))
         self.assertEqual(soil_moisture_data[1].soil_moisture, 400)
 
     def test_get_soil_moisture_empty_database(self):
@@ -119,7 +119,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and ambient light into database."""
         ambient_light_record = db_store.AmbientLightRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, tzinfo=pytz.utc),
             ambient_light=50.0)
         store = db_store.AmbientLightStore(self.mock_connection)
         store.insert(ambient_light_record)
@@ -132,7 +132,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and ambient light into database."""
         ambient_light_record = db_store.AmbientLightRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, tzinfo=UTC_MINUS_5),
             ambient_light=50.0)
         store = db_store.AmbientLightStore(self.mock_connection)
         store.insert(ambient_light_record)
@@ -152,12 +152,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             ambient_light_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, tzinfo=pytz.utc))
         self.assertEqual(ambient_light_data[0].ambient_light, 300)
         self.assertEqual(
             ambient_light_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, tzinfo=pytz.utc))
         self.assertEqual(ambient_light_data[1].ambient_light, 400)
 
     def test_get_ambient_light_empty_database(self):
@@ -170,7 +170,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and humidity level into database."""
         humidity_record = db_store.HumidityRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, tzinfo=pytz.utc),
             humidity=50.0)
         store = db_store.HumidityStore(self.mock_connection)
         store.insert(humidity_record)
@@ -183,7 +183,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and humidity level into database."""
         humidity_record = db_store.HumidityRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, tzinfo=UTC_MINUS_5),
             humidity=50.0)
         store = db_store.HumidityStore(self.mock_connection)
         store.insert(humidity_record)
@@ -202,12 +202,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             humidity_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, tzinfo=pytz.utc))
         self.assertEqual(humidity_data[0].humidity, 50)
         self.assertEqual(
             humidity_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, tzinfo=pytz.utc))
         self.assertEqual(humidity_data[1].humidity, 51)
 
     def test_get_humidity_empty_database(self):
@@ -220,7 +220,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and temperature into database."""
         temperature_record = db_store.TemperatureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, tzinfo=pytz.utc),
             temperature=21.1)
         store = db_store.TemperatureStore(self.mock_connection)
         store.insert(temperature_record)
@@ -233,7 +233,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and temperature into database."""
         temperature_record = db_store.TemperatureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, tzinfo=UTC_MINUS_5),
             temperature=21.1)
         store = db_store.TemperatureStore(self.mock_connection)
         store.insert(temperature_record)
@@ -253,12 +253,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             temperature_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, tzinfo=pytz.utc))
         self.assertEqual(temperature_data[0].temperature, 21.0)
         self.assertEqual(
             temperature_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, tzinfo=pytz.utc))
         self.assertEqual(temperature_data[1].temperature, 21.5)
 
     def test_get_temperature_empty_database(self):
@@ -271,7 +271,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and volume of water pumped into database."""
         watering_event_record = db_store.WateringEventRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, tzinfo=pytz.utc),
             water_pumped=200.0)
         store = db_store.WateringEventStore(self.mock_connection)
         store.insert(watering_event_record)
@@ -284,7 +284,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and volume of water pumped into database."""
         watering_event_record = db_store.WateringEventRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, tzinfo=UTC_MINUS_5),
             water_pumped=200.0)
         store = db_store.WateringEventStore(self.mock_connection)
         store.insert(watering_event_record)
@@ -304,12 +304,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             watering_event_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, tzinfo=pytz.utc))
         self.assertEqual(watering_event_data[0].water_pumped, 300)
         self.assertEqual(
             watering_event_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, tzinfo=pytz.utc))
         self.assertEqual(watering_event_data[1].water_pumped, 301)
 
     def test_get_water_pumped_empty_database(self):

--- a/tests/test_db_store.py
+++ b/tests/test_db_store.py
@@ -68,7 +68,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and moisture level into database."""
         record = db_store.SoilMoistureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
             soil_moisture=300)
         store = db_store.SoilMoistureStore(self.mock_connection)
         store.insert(record)
@@ -81,7 +81,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and moisture level into database."""
         record = db_store.SoilMoistureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
             soil_moisture=300)
         store = db_store.SoilMoistureStore(self.mock_connection)
         store.insert(record)
@@ -101,12 +101,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             soil_moisture_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
         self.assertEqual(soil_moisture_data[0].soil_moisture, 300)
         self.assertEqual(
             soil_moisture_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
         self.assertEqual(soil_moisture_data[1].soil_moisture, 400)
 
     def test_get_soil_moisture_empty_database(self):
@@ -119,7 +119,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and ambient light into database."""
         ambient_light_record = db_store.AmbientLightRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
             ambient_light=50.0)
         store = db_store.AmbientLightStore(self.mock_connection)
         store.insert(ambient_light_record)
@@ -132,7 +132,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and ambient light into database."""
         ambient_light_record = db_store.AmbientLightRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
             ambient_light=50.0)
         store = db_store.AmbientLightStore(self.mock_connection)
         store.insert(ambient_light_record)
@@ -152,12 +152,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             ambient_light_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
         self.assertEqual(ambient_light_data[0].ambient_light, 300)
         self.assertEqual(
             ambient_light_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
         self.assertEqual(ambient_light_data[1].ambient_light, 400)
 
     def test_get_ambient_light_empty_database(self):
@@ -170,7 +170,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and humidity level into database."""
         humidity_record = db_store.HumidityRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
             humidity=50.0)
         store = db_store.HumidityStore(self.mock_connection)
         store.insert(humidity_record)
@@ -183,7 +183,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and humidity level into database."""
         humidity_record = db_store.HumidityRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
             humidity=50.0)
         store = db_store.HumidityStore(self.mock_connection)
         store.insert(humidity_record)
@@ -202,12 +202,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             humidity_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
         self.assertEqual(humidity_data[0].humidity, 50)
         self.assertEqual(
             humidity_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
         self.assertEqual(humidity_data[1].humidity, 51)
 
     def test_get_humidity_empty_database(self):
@@ -220,7 +220,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and temperature into database."""
         temperature_record = db_store.TemperatureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
             temperature=21.1)
         store = db_store.TemperatureStore(self.mock_connection)
         store.insert(temperature_record)
@@ -233,7 +233,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and temperature into database."""
         temperature_record = db_store.TemperatureRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
             temperature=21.1)
         store = db_store.TemperatureStore(self.mock_connection)
         store.insert(temperature_record)
@@ -253,12 +253,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             temperature_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
         self.assertEqual(temperature_data[0].temperature, 21.0)
         self.assertEqual(
             temperature_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
         self.assertEqual(temperature_data[1].temperature, 21.5)
 
     def test_get_temperature_empty_database(self):
@@ -271,7 +271,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and volume of water pumped into database."""
         watering_event_record = db_store.WateringEventRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=pytz.utc),
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc),
             water_pumped=200.0)
         store = db_store.WateringEventStore(self.mock_connection)
         store.insert(watering_event_record)
@@ -284,7 +284,7 @@ class StoreClassesTest(unittest.TestCase):
         """Should insert timestamp and volume of water pumped into database."""
         watering_event_record = db_store.WateringEventRecord(
             timestamp=datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=UTC_MINUS_5),
+                2016, 7, 23, 10, 51, 0, tzinfo=UTC_MINUS_5),
             water_pumped=200.0)
         store = db_store.WateringEventStore(self.mock_connection)
         store.insert(watering_event_record)
@@ -304,12 +304,12 @@ class StoreClassesTest(unittest.TestCase):
         self.assertEqual(
             watering_event_data[0].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 51, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 51, 0, tzinfo=pytz.utc))
         self.assertEqual(watering_event_data[0].water_pumped, 300)
         self.assertEqual(
             watering_event_data[1].timestamp,
             datetime.datetime(
-                2016, 7, 23, 10, 52, tzinfo=pytz.utc))
+                2016, 7, 23, 10, 52, 0, tzinfo=pytz.utc))
         self.assertEqual(watering_event_data[1].water_pumped, 301)
 
     def test_get_water_pumped_empty_database(self):


### PR DESCRIPTION
Now the smallest level of granularity in GreenPiThumb is minutes. Polling
happens in intervals with minute granularity and timestamps are saved with
minutes-level precision.

This fixes #121.