### PR TITLE
Fixing measurement bug in soil moisture sensor

### DIFF
--- a/greenpithumb/moisture_sensor.py
+++ b/greenpithumb/moisture_sensor.py
@@ -41,6 +41,9 @@ class MoistureSensor(object):
             moisture_one = self._adc.read_adc(self._channel)
             logger.info('soil moisture reading (1 of 2) = %d', moisture_one)
 
+            # We need to turn off both pins before the sleep so that the charge
+            # has time to dissipate before the next read.
+            self._pi_io.turn_pin_off(self._gpio_pin_1)
             self._clock.wait(0.1)
 
             self._pi_io.turn_pin_on(self._gpio_pin_2)

--- a/tests/test_moisture_sensor.py
+++ b/tests/test_moisture_sensor.py
@@ -36,9 +36,10 @@ class MoistureSensorTest(unittest.TestCase):
         self.assertEqual(350, sensor.moisture())
         self.assertEqual([mock.call(12), mock.call(16)],
                          self.mock_pi_io.turn_pin_on.call_args_list)
-        self.assertEqual(
-            [mock.call(16), mock.call(12), mock.call(12), mock.call(16)],
-            self.mock_pi_io.turn_pin_off.call_args_list)
+        self.assertEqual([
+            mock.call(16), mock.call(12), mock.call(12), mock.call(12),
+            mock.call(16)
+        ], self.mock_pi_io.turn_pin_off.call_args_list)
         self.assertFalse(self.pin_state[12])
         self.assertFalse(self.pin_state[16])
         self.mock_clock.wait.assert_called_once_with(0.1)


### PR DESCRIPTION
The second reading was coming in wrong because we weren't turning off both
GPIO pins before we slept, so there was probably some remnant charge on the
first pin during the second read. Adding in a turn_pin_off call to ensure
that both pins are off and have time for the charge to dissipate.