### PR TITLE
Changing moisture threshold to flag

### DIFF
--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -63,37 +63,39 @@ class PumpManagerTest(unittest.TestCase):
     def setUp(self):
         self.mock_pump = mock.Mock()
         self.mock_pump_scheduler = mock.Mock()
-        self.manager = pump.PumpManager(self.mock_pump,
-                                        self.mock_pump_scheduler)
 
     def test_low_moisture_triggers_pump(self):
+        manager = pump.PumpManager(self.mock_pump, self.mock_pump_scheduler,
+                                   300)
         self.mock_pump_scheduler.is_running_pump_allowed.return_value = True
-        moisture = pump.SOIL_MOISTURE_THRESHOLD - 100
-        ml_pumped = self.manager.pump_if_needed(moisture)
+        ml_pumped = manager.pump_if_needed(200)
         self.mock_pump.pump_water.assert_called_once_with(
             pump.DEFAULT_PUMP_AMOUNT)
         self.assertEqual(ml_pumped, pump.DEFAULT_PUMP_AMOUNT)
 
     def test_pump_not_triggered_if_moisture_is_at_threshold(self):
+        manager = pump.PumpManager(self.mock_pump, self.mock_pump_scheduler,
+                                   300)
         self.mock_pump_scheduler.is_running_pump_allowed.return_value = True
-        moisture = pump.SOIL_MOISTURE_THRESHOLD
-        ml_pumped = self.manager.pump_if_needed(moisture)
+        ml_pumped = manager.pump_if_needed(300)
         # Pump should not run if soil moisture is exactly at threshold.
         self.assertFalse(self.mock_pump.pump_water.called)
         self.assertEqual(ml_pumped, 0)
 
     def test_pump_not_triggered_if_moisture_is_high(self):
+        manager = pump.PumpManager(self.mock_pump, self.mock_pump_scheduler,
+                                   300)
         self.mock_pump_scheduler.is_running_pump_allowed.return_value = True
-        moisture = pump.SOIL_MOISTURE_THRESHOLD + 350
-        ml_pumped = self.manager.pump_if_needed(moisture)
+        ml_pumped = manager.pump_if_needed(650)
         # Pump should not run if soil moisture is above threshold.
         self.assertFalse(self.mock_pump.pump_water.called)
         self.assertEqual(ml_pumped, 0)
 
     def test_pump_is_disabled_during_quiet_hours(self):
+        manager = pump.PumpManager(self.mock_pump, self.mock_pump_scheduler,
+                                   300)
         self.mock_pump_scheduler.is_running_pump_allowed.return_value = False
-        moisture = pump.SOIL_MOISTURE_THRESHOLD - 100
-        ml_pumped = self.manager.pump_if_needed(moisture)
+        ml_pumped = manager.pump_if_needed(200)
         self.assertFalse(self.mock_pump.pump_water.called)
         self.assertEqual(ml_pumped, 0)
 


### PR DESCRIPTION
It looks like moisture levels may vary from system to system, so instead of
hardcoding the moisture threshold at which the pump starts running, we make
it a command-line flag so that it is easily configurable.