### PR TITLE
Changing poll intervals to be timedelta

### DIFF
--- a/greenpithumb/poller.py
+++ b/greenpithumb/poller.py
@@ -23,8 +23,8 @@ class SensorPollerFactory(object):
 
         Args:
             clock: A clock interface.
-            poll_interval: An int of how often the data should be polled for,
-                in minutes.
+            poll_interval: A timedelta of how often the data should be polled
+                for.
             record_queue: Queue on which to place database records.
         """
         self._clock = clock
@@ -86,8 +86,8 @@ class _SensorPollWorkerBase(object):
 
         Args:
             clock: A clock interface.
-            poll_interval: An int of how often the data should be polled for,
-                in minutes.
+            poll_interval: A timedelta of how often the data should be polled
+                for.
             record_queue: Queue on which to place database records.
             sensor: A sensor to poll for status. The particular type of sensor
                 will vary depending on the poll worker subclass.
@@ -127,10 +127,10 @@ class _SensorPollWorkerBase(object):
         Returns:
             UNIX time of next scheduled poll.
         """
-        next_poll_time = _round_up_to_multiple(self._unix_now(),
-                                               self._poll_interval)
+        next_poll_time = _round_up_to_multiple(
+            self._unix_now(), int(self._poll_interval.total_seconds()))
         if last_poll_time and (next_poll_time == last_poll_time):
-            next_poll_time += (self._poll_interval * _SECONDS_PER_MINUTE)
+            next_poll_time += int(self._poll_interval.total_seconds())
         return next_poll_time
 
     def _is_stopped(self):
@@ -194,8 +194,8 @@ class _SoilWateringPollWorker(_SensorPollWorkerBase):
 
         Args:
             clock: A clock interface.
-            poll_interval: An int of how often the data should be polled for,
-                in minutes.
+            poll_interval: A timedelta of how often the data should be polled
+                for.
             record_queue: Queue on which to place soil moisture records and
                 watering event records for storage.
             soil_moisture_sensor: An interface for reading the soil moisture

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -11,7 +11,6 @@ from greenpithumb import db_store
 from greenpithumb import poller
 
 TEST_TIMEOUT_SECONDS = 3.0
-POLL_INTERVAL = 15
 TIMESTAMP_A = datetime.datetime(2016, 7, 23, 10, 51, 9, 928000, tzinfo=pytz.utc)
 # TIMESTAMP_B is on the poll interval boundary immediately after TIMESTAMP_A.
 TIMESTAMP_B = datetime.datetime(2016, 7, 23, 10, 51, 15, 0, tzinfo=pytz.utc)
@@ -26,9 +25,10 @@ class PollerTest(unittest.TestCase):
             lambda _: self.clock_wait_event.set())
         self.mock_sensor = mock.Mock()
         self.mock_store = mock.Mock()
+        poll_interval = datetime.timedelta(seconds=15)
         self.record_queue = Queue.Queue()
         self.factory = poller.SensorPollerFactory(
-            self.mock_clock, POLL_INTERVAL, self.record_queue)
+            self.mock_clock, poll_interval, self.record_queue)
 
     def block_until_clock_wait_call(self):
         """Blocks until the clock's wait method is called or test times out."""


### PR DESCRIPTION
This fixes a bug in poller where it was treating the interval as seconds in
one spot and minutes in another.

This is really a temporary workaround until we refactor out the poll
scheduling logic because I think this bug shows we're not testing it
sufficiently and the way the code is currently organized, it's hard to test
the poll scheduling part.