### PR TITLE
Fixing build script to return non-zero exit on YAPF diff

### DIFF
--- a/build
+++ b/build
@@ -15,13 +15,18 @@ coverage run \
 pyflakes greenpithumb/*.py tests/*.py
 
 # Check that source has correct formatting.
-yapf \
+DIFF=$(yapf \
   --diff \
   --recursive \
   --style google \
   ./ \
   --exclude "./greenpithumb/dht11/*" \
-  --exclude "./third_party/*"
+  --exclude "./third_party/*")
+if [ -n "${DIFF}" ]; then
+  echo "FAIL: Formatting does not match style:"
+  echo "${DIFF}"
+  exit 1
+fi
 
 # Check that docstrings are formatted correctly.
 PYTHONPATH=$PYTHONPATH:$(pwd)/third_party/docstringchecker \


### PR DESCRIPTION
YAPF changed behavior so it no longer returns a non-zero exit code on a diff
(see https://github.com/google/yapf/issues/325). This updates the build script
so that the build fails if there's a YAPF diff.