### PR TITLE
Observe pump_interval across restarts

### DIFF
--- a/greenpithumb/clock.py
+++ b/greenpithumb/clock.py
@@ -46,6 +46,17 @@ class Timer(object):
         self.reset()
 
     def set_remaining(self, time_remaining):
+        """Adjusts the remaining time on the timer.
+
+        Args:
+            time_remaining: The new amount of time remaining before the timer
+                expires. Must be a timedelta between 0 seconds and the timer
+                duration (inclusive).
+
+        Raises:
+            ValueError if time_remaining is a negative timedelta or is longer
+            than the timer's duration.
+        """
         if time_remaining < datetime.timedelta(seconds=0):
             raise ValueError('time_remaining must be non-negative')
         if time_remaining > self._duration:

--- a/greenpithumb/clock.py
+++ b/greenpithumb/clock.py
@@ -43,12 +43,20 @@ class Timer(object):
         """
         self._clock = clock
         self._duration = duration
-        self._start_time = self._clock.now()
+        self.reset()
+
+    def set_remaining(self, time_remaining):
+        if time_remaining < datetime.timedelta(seconds=0):
+            raise ValueError('time_remaining must be non-negative')
+        if time_remaining > self._duration:
+            raise ValueError(
+                'Cannot set time_remaining to longer than duration')
+        self._end_time = self._clock.now() + time_remaining
 
     def expired(self):
         """Returns True if the countdown has expired."""
-        return (self._clock.now() - self._start_time) >= self._duration
+        return self._clock.now() >= self._end_time
 
     def reset(self):
         """Resets the countdown timer to its starting duration."""
-        self._start_time = self._clock.now()
+        self._end_time = self._clock.now() + self._duration

--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -150,8 +150,8 @@ def make_pump_manager(moisture_threshold, sleep_windows, raspberry_pi_io,
             (last_pump_time + pump_interval) - clock.Clock().now())
     else:
         logger.info('no previous watering found')
-        time_remaining = pump_interval
-    logger.info('max time until until next watering: %s', time_remaining)
+        time_remaining = datetime.timedelta(seconds=0)
+    logger.info('time until until next watering: %s', time_remaining)
     pump_timer.set_remaining(time_remaining)
     return pump.PumpManager(water_pump, pump_scheduler, moisture_threshold,
                             pump_amount, pump_timer)

--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -20,6 +20,7 @@ import light_sensor
 import pi_io
 import poller
 import pump
+import pump_history
 import record_processor
 import sleep_windows
 import soil_moisture_sensor
@@ -120,7 +121,7 @@ def make_camera_manager(rotation, image_path, light_sensor):
 
 
 def make_pump_manager(moisture_threshold, sleep_windows, raspberry_pi_io,
-                      wiring_config, pump_amount, pump_interval):
+                      wiring_config, pump_amount, db_connection, pump_interval):
     """Creates a pump manager instance.
 
     Args:
@@ -130,6 +131,7 @@ def make_pump_manager(moisture_threshold, sleep_windows, raspberry_pi_io,
         raspberry_pi_io: pi_io instance for the GreenPiThumb.
         wiring_config: Wiring configuration for the GreenPiThumb.
         pump_amount: Amount (in mL) to pump on each run of the pump.
+        db_connection: Database connection to use to retrieve pump history.
         pump_interval: Maximum amount of time between pump runs.
 
     Returns:
@@ -139,6 +141,13 @@ def make_pump_manager(moisture_threshold, sleep_windows, raspberry_pi_io,
                            clock.Clock(), wiring_config.gpio_pins.pump)
     pump_scheduler = pump.PumpScheduler(clock.LocalClock(), sleep_windows)
     pump_timer = clock.Timer(clock.Clock(), pump_interval)
+    last_pump_time = pump_history.last_pump_time(
+        db_store.WateringEventStore(db_connection))
+    logger.info('last watering was at %s', last_pump_time)
+    time_remaining = max(datetime.timedelta(seconds=0),
+                         (last_pump_time + pump_interval) - clock.Clock().now())
+    logger.info('max time until until next watering: %s', time_remaining)
+    pump_timer.set_remaining(time_remaining)
     return pump.PumpManager(water_pump, pump_scheduler, moisture_threshold,
                             pump_amount, pump_timer)
 
@@ -215,27 +224,28 @@ def main(args):
     local_light_sensor = make_light_sensor(adc, wiring_config)
     camera_manager = make_camera_manager(args.camera_rotation, args.image_path,
                                          local_light_sensor)
-    pump_manager = make_pump_manager(
-        args.moisture_threshold,
-        sleep_windows.parse(args.sleep_window),
-        raspberry_pi_io,
-        wiring_config,
-        args.pump_amount,
-        datetime.timedelta(hours=args.pump_interval))
-    pollers = make_sensor_pollers(
-        datetime.timedelta(minutes=args.poll_interval),
-        datetime.timedelta(minutes=args.photo_interval),
-        record_queue,
-        local_temperature_sensor,
-        local_humidity_sensor,
-        local_soil_moisture_sensor,
-        local_light_sensor,
-        camera_manager,
-        pump_manager)
 
     with contextlib.closing(db_store.open_or_create_db(
             args.db_file)) as db_connection:
         record_processor = create_record_processor(db_connection, record_queue)
+        pump_manager = make_pump_manager(
+            args.moisture_threshold,
+            sleep_windows.parse(args.sleep_window),
+            raspberry_pi_io,
+            wiring_config,
+            args.pump_amount,
+            db_connection,
+            datetime.timedelta(hours=args.pump_interval))
+        pollers = make_sensor_pollers(
+            datetime.timedelta(minutes=args.poll_interval),
+            datetime.timedelta(minutes=args.photo_interval),
+            record_queue,
+            local_temperature_sensor,
+            local_humidity_sensor,
+            local_soil_moisture_sensor,
+            local_light_sensor,
+            camera_manager,
+            pump_manager)
         try:
             for current_poller in pollers:
                 current_poller.start_polling_async()
@@ -277,7 +287,7 @@ if __name__ == '__main__':
         '--pump_interval',
         type=float,
         help='Max number of hours between plant waterings',
-        default=(3 * 24))
+        default=(7 * 24))
     parser.add_argument(
         '-c',
         '--config_file',
@@ -309,7 +319,7 @@ if __name__ == '__main__':
         type=int,
         help=('Moisture threshold to start pump. The pump will turn on if the '
               'moisture level drops below this level'),
-        default=900)
+        default=0)
     parser.add_argument(
         '--camera_rotation',
         type=int,

--- a/greenpithumb/greenpithumb.py
+++ b/greenpithumb/greenpithumb.py
@@ -143,9 +143,14 @@ def make_pump_manager(moisture_threshold, sleep_windows, raspberry_pi_io,
     pump_timer = clock.Timer(clock.Clock(), pump_interval)
     last_pump_time = pump_history.last_pump_time(
         db_store.WateringEventStore(db_connection))
-    logger.info('last watering was at %s', last_pump_time)
-    time_remaining = max(datetime.timedelta(seconds=0),
-                         (last_pump_time + pump_interval) - clock.Clock().now())
+    if last_pump_time:
+        logger.info('last watering was at %s', last_pump_time)
+        time_remaining = max(
+            datetime.timedelta(seconds=0),
+            (last_pump_time + pump_interval) - clock.Clock().now())
+    else:
+        logger.info('no previous watering found')
+        time_remaining = pump_interval
     logger.info('max time until until next watering: %s', time_remaining)
     pump_timer.set_remaining(time_remaining)
     return pump.PumpManager(water_pump, pump_scheduler, moisture_threshold,

--- a/greenpithumb/pump_history.py
+++ b/greenpithumb/pump_history.py
@@ -1,0 +1,15 @@
+def last_pump_time(watering_event_store):
+    """Returns the time of the most recent pump watering event.
+
+    Args:
+        watering_event_store: Database store from which to retrieve watering
+            event history.
+
+    Returns:
+        Timestamp of most recent pump watering event, as a datetime.
+    """
+    watering_history = watering_event_store.get()
+    if len(watering_history) == 0:
+        return None
+    watering_history.sort(key=lambda record: record.timestamp)
+    return watering_history[-1].timestamp

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -69,6 +69,50 @@ class TimerTest(unittest.TestCase):
         ]  # yapf: disable
         self.assertFalse(clock.Timer(self.mock_clock, duration).expired())
 
+    def test_set_remaining_fails_when_remaining_is_longer_than_duration(self):
+        duration = datetime.timedelta(days=3)
+        self.mock_clock.now.return_value = datetime.datetime(
+            2000, 1, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+        timer = clock.Timer(self.mock_clock, duration)
+        with self.assertRaises(ValueError):
+            timer.set_remaining(datetime.timedelta(days=4))
+
+    def test_set_remaining_fails_when_remaining_is_negative(self):
+        duration = datetime.timedelta(days=3)
+        self.mock_clock.now.return_value = datetime.datetime(
+            2000, 1, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+        timer = clock.Timer(self.mock_clock, duration)
+        with self.assertRaises(ValueError):
+            timer.set_remaining(datetime.timedelta(days=-1))
+
+    def test_set_remaining_succeeds_when_remaining_is_zero(self):
+        duration = datetime.timedelta(days=3)
+        self.mock_clock.now.return_value = datetime.datetime(
+            2000, 1, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+        timer = clock.Timer(self.mock_clock, duration)
+        timer.set_remaining(datetime.timedelta(seconds=0))
+        self.assertTrue(timer.expired())
+
+    def test_set_remaining_succeeds_when_remaining_equals_duration(self):
+        duration = datetime.timedelta(days=3)
+        self.mock_clock.now.return_value = datetime.datetime(
+            2000, 1, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+        timer = clock.Timer(self.mock_clock, duration)
+        timer.set_remaining(datetime.timedelta(days=3))
+        self.mock_clock.now.return_value = datetime.datetime(
+            2000, 1, 4, 0, 0, 0, 0, tzinfo=pytz.utc)
+        self.assertTrue(timer.expired())
+
+    def test_set_remaining_succeeds_when_remaining_is_less_than_duration(self):
+        duration = datetime.timedelta(days=3)
+        self.mock_clock.now.return_value = datetime.datetime(
+            2000, 1, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
+        timer = clock.Timer(self.mock_clock, duration)
+        timer.set_remaining(datetime.timedelta(days=1))
+        self.mock_clock.now.return_value = datetime.datetime(
+            2000, 1, 2, 0, 0, 0, 0, tzinfo=pytz.utc)
+        self.assertTrue(timer.expired())
+
     def test_reset(self):
         duration = datetime.timedelta(hours=3 * 24)
         self.mock_clock.now.return_value = datetime.datetime(

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -100,6 +100,9 @@ class TimerTest(unittest.TestCase):
         timer = clock.Timer(self.mock_clock, duration)
         timer.set_remaining(datetime.timedelta(days=3))
         self.mock_clock.now.return_value = datetime.datetime(
+            2000, 1, 3, 23, 59, 59, 999999, tzinfo=pytz.utc)
+        self.assertFalse(timer.expired())
+        self.mock_clock.now.return_value = datetime.datetime(
             2000, 1, 4, 0, 0, 0, 0, tzinfo=pytz.utc)
         self.assertTrue(timer.expired())
 
@@ -109,6 +112,9 @@ class TimerTest(unittest.TestCase):
             2000, 1, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
         timer = clock.Timer(self.mock_clock, duration)
         timer.set_remaining(datetime.timedelta(days=1))
+        self.mock_clock.now.return_value = datetime.datetime(
+            2000, 1, 1, 23, 59, 59, 999999, tzinfo=pytz.utc)
+        self.assertFalse(timer.expired())
         self.mock_clock.now.return_value = datetime.datetime(
             2000, 1, 2, 0, 0, 0, 0, tzinfo=pytz.utc)
         self.assertTrue(timer.expired())

--- a/tests/test_pump_history.py
+++ b/tests/test_pump_history.py
@@ -1,0 +1,42 @@
+import datetime
+import unittest
+
+import mock
+import pytz
+
+from greenpithumb import pump_history
+
+
+class TestPumpHistory(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_watering_event_store = mock.Mock()
+
+    def test_last_pump_time_returns_None_when_db_is_empty(self):
+        self.mock_watering_event_store.get.return_value = []
+        self.assertEqual(
+            None, pump_history.last_pump_time(self.mock_watering_event_store))
+
+    def test_last_pump_time_returns_timestamp_when_only_one_event_in_db(self):
+        self.mock_watering_event_store.get.return_value = [
+            mock.Mock(timestamp=datetime.datetime(
+                2017, 1, 1, 12, 45, 9, 123456, tzinfo=pytz.utc))
+        ]
+        self.assertEqual(
+            datetime.datetime(
+                2017, 1, 1, 12, 45, 9, 123456, tzinfo=pytz.utc),
+            pump_history.last_pump_time(self.mock_watering_event_store))
+
+    def test_last_pump_time_returns_timestamp_when_db_has_many_events(self):
+        self.mock_watering_event_store.get.return_value = [
+            mock.Mock(timestamp=datetime.datetime(
+                2016, 1, 1, 12, 45, 9, 123456, tzinfo=pytz.utc)),
+            mock.Mock(timestamp=datetime.datetime(
+                2017, 3, 2, 0, 15, 59, 987654, tzinfo=pytz.utc)),
+            mock.Mock(timestamp=datetime.datetime(
+                2015, 12, 5, 12, 45, 9, 555555, tzinfo=pytz.utc)),
+        ]
+        self.assertEqual(
+            datetime.datetime(
+                2017, 3, 2, 0, 15, 59, 987654, tzinfo=pytz.utc),
+            pump_history.last_pump_time(self.mock_watering_event_store))


### PR DESCRIPTION
Adds a lookup in the database on startup to find the last recorded time that
GreenPiThumb ran the pump.

To support this, changes the Timer interface to support setting an explicit
time remaining that may differ from the duration.